### PR TITLE
Update OpenAPI spec to v1.0.3 with new endpoints and changes

### DIFF
--- a/frontend/src/services/api/semanticBrowseComponents.ts
+++ b/frontend/src/services/api/semanticBrowseComponents.ts
@@ -20,7 +20,7 @@ export type LogoutError = Fetcher.ErrorWrapper<{
 
 export type LogoutResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -60,7 +60,7 @@ export type VerifyEmailError = Fetcher.ErrorWrapper<{
 
 export type VerifyEmailResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -119,7 +119,7 @@ export type ResendVerificationEmailError = Fetcher.ErrorWrapper<{
 
 export type ResendVerificationEmailResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -178,7 +178,7 @@ export type ResetPasswordRequestError = Fetcher.ErrorWrapper<{
 
 export type ResetPasswordRequestResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -248,7 +248,7 @@ export type ResetPasswordError = Fetcher.ErrorWrapper<{
 
 export type ResetPasswordResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -349,7 +349,7 @@ export type LoginError = Fetcher.ErrorWrapper<{
 
 export type LoginResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -392,7 +392,7 @@ export type GetUserByIdError = Fetcher.ErrorWrapper<{
 
 export type GetUserByIdResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -451,7 +451,7 @@ export type UpdateUserByIdError = Fetcher.ErrorWrapper<{
 
 export type UpdateUserByIdResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -465,6 +465,9 @@ export type UpdateUserByIdVariables = {
   pathParams: UpdateUserByIdPathParams;
 } & SemanticBrowseContext["fetcherOptions"];
 
+/**
+ * Can only update own profile
+ */
 export const fetchUpdateUserById = (
   variables: UpdateUserByIdVariables,
   signal?: AbortSignal,
@@ -478,6 +481,9 @@ export const fetchUpdateUserById = (
     UpdateUserByIdPathParams
   >({ url: "/users/{userId}", method: "put", ...variables, signal });
 
+/**
+ * Can only update own profile
+ */
 export const useUpdateUserById = (
   options?: Omit<
     reactQuery.UseMutationOptions<
@@ -511,7 +517,7 @@ export type GetUserFollowingError = Fetcher.ErrorWrapper<{
 
 export type GetUserFollowingResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -578,7 +584,7 @@ export type GetUserFollowersError = Fetcher.ErrorWrapper<{
 
 export type GetUserFollowersResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -634,6 +640,10 @@ export const useGetUserFollowers = <TData = GetUserFollowersResponse>(
   });
 };
 
+export type FollowUserPathParams = {
+  userId: number;
+};
+
 export type FollowUserError = Fetcher.ErrorWrapper<
   | {
       status: 400;
@@ -645,12 +655,19 @@ export type FollowUserError = Fetcher.ErrorWrapper<
     }
 >;
 
-export type FollowUserRequestBody = {
-  followingUserId?: number;
+export type FollowUserResponse = {
+  /**
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
+   *
+   * @example 200
+   * @example 201
+   */
+  status: 200 | 201;
+  data: Schemas.UserProfile;
 };
 
 export type FollowUserVariables = {
-  body?: FollowUserRequestBody;
+  pathParams: FollowUserPathParams;
 } & SemanticBrowseContext["fetcherOptions"];
 
 export const fetchFollowUser = (
@@ -658,18 +675,18 @@ export const fetchFollowUser = (
   signal?: AbortSignal,
 ) =>
   semanticBrowseFetch<
-    Responses.OkResponse,
+    FollowUserResponse,
     FollowUserError,
-    FollowUserRequestBody,
+    undefined,
     {},
     {},
-    {}
-  >({ url: "/users/follow", method: "post", ...variables, signal });
+    FollowUserPathParams
+  >({ url: "/users/{userId}/follow", method: "post", ...variables, signal });
 
 export const useFollowUser = (
   options?: Omit<
     reactQuery.UseMutationOptions<
-      Responses.OkResponse,
+      FollowUserResponse,
       FollowUserError,
       FollowUserVariables
     >,
@@ -678,7 +695,7 @@ export const useFollowUser = (
 ) => {
   const { fetcherOptions } = useSemanticBrowseContext();
   return reactQuery.useMutation<
-    Responses.OkResponse,
+    FollowUserResponse,
     FollowUserError,
     FollowUserVariables
   >({
@@ -686,6 +703,10 @@ export const useFollowUser = (
       fetchFollowUser({ ...fetcherOptions, ...variables }),
     ...options,
   });
+};
+
+export type UnfollowUserPathParams = {
+  userId: number;
 };
 
 export type UnfollowUserError = Fetcher.ErrorWrapper<
@@ -699,12 +720,19 @@ export type UnfollowUserError = Fetcher.ErrorWrapper<
     }
 >;
 
-export type UnfollowUserRequestBody = {
-  followingUserId?: number;
+export type UnfollowUserResponse = {
+  /**
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
+   *
+   * @example 200
+   * @example 201
+   */
+  status: 200 | 201;
+  data: Schemas.UserProfile;
 };
 
 export type UnfollowUserVariables = {
-  body?: UnfollowUserRequestBody;
+  pathParams: UnfollowUserPathParams;
 } & SemanticBrowseContext["fetcherOptions"];
 
 export const fetchUnfollowUser = (
@@ -712,18 +740,18 @@ export const fetchUnfollowUser = (
   signal?: AbortSignal,
 ) =>
   semanticBrowseFetch<
-    Responses.OkResponse,
+    UnfollowUserResponse,
     UnfollowUserError,
-    UnfollowUserRequestBody,
+    undefined,
     {},
     {},
-    {}
-  >({ url: "/users/unfollow", method: "post", ...variables, signal });
+    UnfollowUserPathParams
+  >({ url: "/users/{userId}/follow", method: "delete", ...variables, signal });
 
 export const useUnfollowUser = (
   options?: Omit<
     reactQuery.UseMutationOptions<
-      Responses.OkResponse,
+      UnfollowUserResponse,
       UnfollowUserError,
       UnfollowUserVariables
     >,
@@ -732,7 +760,7 @@ export const useUnfollowUser = (
 ) => {
   const { fetcherOptions } = useSemanticBrowseContext();
   return reactQuery.useMutation<
-    Responses.OkResponse,
+    UnfollowUserResponse,
     UnfollowUserError,
     UnfollowUserVariables
   >({
@@ -753,7 +781,7 @@ export type SearchUsersError = Fetcher.ErrorWrapper<{
 
 export type SearchUsersResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -815,7 +843,7 @@ export type SearchDishesError = Fetcher.ErrorWrapper<{
 export type SearchDishesResponse = {
   data: Schemas.DishArray;
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -873,7 +901,7 @@ export type GetDishByIdError = Fetcher.ErrorWrapper<{
 
 export type GetDishByIdResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -936,7 +964,7 @@ export type GetCuisineByIdError = Fetcher.ErrorWrapper<{
 
 export type GetCuisineByIdResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -993,6 +1021,76 @@ export const useGetCuisineById = <TData = GetCuisineByIdResponse>(
   });
 };
 
+export type FollowCuisinePathParams = {
+  cuisineId: number;
+};
+
+export type FollowCuisineError = Fetcher.ErrorWrapper<
+  | {
+      status: 400;
+      payload: Responses.BadRequestResponse;
+    }
+  | {
+      status: 404;
+      payload: Responses.NotFoundResponse;
+    }
+>;
+
+export type FollowCuisineResponse = {
+  /**
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
+   *
+   * @example 200
+   * @example 201
+   */
+  status: 200 | 201;
+  data: Schemas.CuisineDetails;
+};
+
+export type FollowCuisineVariables = {
+  pathParams: FollowCuisinePathParams;
+} & SemanticBrowseContext["fetcherOptions"];
+
+export const fetchFollowCuisine = (
+  variables: FollowCuisineVariables,
+  signal?: AbortSignal,
+) =>
+  semanticBrowseFetch<
+    FollowCuisineResponse,
+    FollowCuisineError,
+    undefined,
+    {},
+    {},
+    FollowCuisinePathParams
+  >({
+    url: "/cuisines/{cuisineId}/follow",
+    method: "post",
+    ...variables,
+    signal,
+  });
+
+export const useFollowCuisine = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      FollowCuisineResponse,
+      FollowCuisineError,
+      FollowCuisineVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useSemanticBrowseContext();
+  return reactQuery.useMutation<
+    FollowCuisineResponse,
+    FollowCuisineError,
+    FollowCuisineVariables
+  >({
+    mutationFn: (variables: FollowCuisineVariables) =>
+      fetchFollowCuisine({ ...fetcherOptions, ...variables }),
+    ...options,
+  });
+};
+
 export type GetRecipesForEntityQueryParams = {
   sort?: "recent" | "topRated";
   dishId?: number;
@@ -1006,7 +1104,7 @@ export type GetRecipesForEntityError = Fetcher.ErrorWrapper<{
 
 export type GetRecipesForEntityResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -1069,7 +1167,7 @@ export type CreateRecipeError = Fetcher.ErrorWrapper<{
 
 export type CreateRecipeResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -1128,7 +1226,7 @@ export type GetRecipeByIdError = Fetcher.ErrorWrapper<{
 
 export type GetRecipeByIdResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -1296,6 +1394,78 @@ export const useRateRecipe = (
   });
 };
 
+export type GetBookmarkersPathParams = {
+  recipeId: number;
+};
+
+export type GetBookmarkersError = Fetcher.ErrorWrapper<{
+  status: 404;
+  payload: Responses.NotFoundResponse;
+}>;
+
+export type GetBookmarkersResponse = {
+  /**
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
+   *
+   * @example 200
+   * @example 201
+   */
+  status: 200 | 201;
+  data: Schemas.UserArray;
+};
+
+export type GetBookmarkersVariables = {
+  pathParams: GetBookmarkersPathParams;
+} & SemanticBrowseContext["fetcherOptions"];
+
+export const fetchGetBookmarkers = (
+  variables: GetBookmarkersVariables,
+  signal?: AbortSignal,
+) =>
+  semanticBrowseFetch<
+    GetBookmarkersResponse,
+    GetBookmarkersError,
+    undefined,
+    {},
+    {},
+    GetBookmarkersPathParams
+  >({
+    url: "/recipes/{recipeId}/bookmarks",
+    method: "get",
+    ...variables,
+    signal,
+  });
+
+export const useGetBookmarkers = <TData = GetBookmarkersResponse>(
+  variables: GetBookmarkersVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      GetBookmarkersResponse,
+      GetBookmarkersError,
+      TData
+    >,
+    "queryKey" | "queryFn" | "initialData"
+  >,
+) => {
+  const { fetcherOptions, queryOptions, queryKeyFn } =
+    useSemanticBrowseContext(options);
+  return reactQuery.useQuery<
+    GetBookmarkersResponse,
+    GetBookmarkersError,
+    TData
+  >({
+    queryKey: queryKeyFn({
+      path: "/recipes/{recipeId}/bookmarks",
+      operationId: "getBookmarkers",
+      variables,
+    }),
+    queryFn: ({ signal }) =>
+      fetchGetBookmarkers({ ...fetcherOptions, ...variables }, signal),
+    ...options,
+    ...queryOptions,
+  });
+};
+
 export type BookmarkRecipePathParams = {
   recipeId: number;
 };
@@ -1321,7 +1491,7 @@ export const fetchBookmarkRecipe = (
     {},
     BookmarkRecipePathParams
   >({
-    url: "/recipes/{recipeId}/bookmark",
+    url: "/recipes/{recipeId}/bookmarks",
     method: "post",
     ...variables,
     signal,
@@ -1349,6 +1519,330 @@ export const useBookmarkRecipe = (
   });
 };
 
+export type UnbookmarkRecipePathParams = {
+  recipeId: number;
+};
+
+export type UnbookmarkRecipeError = Fetcher.ErrorWrapper<{
+  status: 400;
+  payload: Responses.BadRequestResponse;
+}>;
+
+export type UnbookmarkRecipeVariables = {
+  pathParams: UnbookmarkRecipePathParams;
+} & SemanticBrowseContext["fetcherOptions"];
+
+export const fetchUnbookmarkRecipe = (
+  variables: UnbookmarkRecipeVariables,
+  signal?: AbortSignal,
+) =>
+  semanticBrowseFetch<
+    Responses.OkResponse,
+    UnbookmarkRecipeError,
+    undefined,
+    {},
+    {},
+    UnbookmarkRecipePathParams
+  >({
+    url: "/recipes/{recipeId}/bookmarks",
+    method: "delete",
+    ...variables,
+    signal,
+  });
+
+export const useUnbookmarkRecipe = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      Responses.OkResponse,
+      UnbookmarkRecipeError,
+      UnbookmarkRecipeVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useSemanticBrowseContext();
+  return reactQuery.useMutation<
+    Responses.OkResponse,
+    UnbookmarkRecipeError,
+    UnbookmarkRecipeVariables
+  >({
+    mutationFn: (variables: UnbookmarkRecipeVariables) =>
+      fetchUnbookmarkRecipe({ ...fetcherOptions, ...variables }),
+    ...options,
+  });
+};
+
+export type GetCommentsForRecipePathParams = {
+  recipeId: number;
+};
+
+export type GetCommentsForRecipeError = Fetcher.ErrorWrapper<{
+  status: 404;
+  payload: Responses.NotFoundResponse;
+}>;
+
+export type GetCommentsForRecipeResponse = {
+  /**
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
+   *
+   * @example 200
+   * @example 201
+   */
+  status: 200 | 201;
+  data: Schemas.CommentArray;
+};
+
+export type GetCommentsForRecipeVariables = {
+  pathParams: GetCommentsForRecipePathParams;
+} & SemanticBrowseContext["fetcherOptions"];
+
+export const fetchGetCommentsForRecipe = (
+  variables: GetCommentsForRecipeVariables,
+  signal?: AbortSignal,
+) =>
+  semanticBrowseFetch<
+    GetCommentsForRecipeResponse,
+    GetCommentsForRecipeError,
+    undefined,
+    {},
+    {},
+    GetCommentsForRecipePathParams
+  >({
+    url: "/recipes/{recipeId}/comments",
+    method: "get",
+    ...variables,
+    signal,
+  });
+
+export const useGetCommentsForRecipe = <TData = GetCommentsForRecipeResponse>(
+  variables: GetCommentsForRecipeVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      GetCommentsForRecipeResponse,
+      GetCommentsForRecipeError,
+      TData
+    >,
+    "queryKey" | "queryFn" | "initialData"
+  >,
+) => {
+  const { fetcherOptions, queryOptions, queryKeyFn } =
+    useSemanticBrowseContext(options);
+  return reactQuery.useQuery<
+    GetCommentsForRecipeResponse,
+    GetCommentsForRecipeError,
+    TData
+  >({
+    queryKey: queryKeyFn({
+      path: "/recipes/{recipeId}/comments",
+      operationId: "getCommentsForRecipe",
+      variables,
+    }),
+    queryFn: ({ signal }) =>
+      fetchGetCommentsForRecipe({ ...fetcherOptions, ...variables }, signal),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+export type AddCommentToRecipePathParams = {
+  recipeId: number;
+};
+
+export type AddCommentToRecipeError = Fetcher.ErrorWrapper<{
+  status: 400;
+  payload: Responses.BadRequestResponse;
+}>;
+
+export type AddCommentToRecipeResponse = {
+  /**
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
+   *
+   * @example 200
+   * @example 201
+   */
+  status: 200 | 201;
+  data: Schemas.Comment;
+};
+
+export type AddCommentToRecipeRequestBody = {
+  comment?: string;
+};
+
+export type AddCommentToRecipeVariables = {
+  body?: AddCommentToRecipeRequestBody;
+  pathParams: AddCommentToRecipePathParams;
+} & SemanticBrowseContext["fetcherOptions"];
+
+export const fetchAddCommentToRecipe = (
+  variables: AddCommentToRecipeVariables,
+  signal?: AbortSignal,
+) =>
+  semanticBrowseFetch<
+    AddCommentToRecipeResponse,
+    AddCommentToRecipeError,
+    AddCommentToRecipeRequestBody,
+    {},
+    {},
+    AddCommentToRecipePathParams
+  >({
+    url: "/recipes/{recipeId}/comments",
+    method: "post",
+    ...variables,
+    signal,
+  });
+
+export const useAddCommentToRecipe = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      AddCommentToRecipeResponse,
+      AddCommentToRecipeError,
+      AddCommentToRecipeVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useSemanticBrowseContext();
+  return reactQuery.useMutation<
+    AddCommentToRecipeResponse,
+    AddCommentToRecipeError,
+    AddCommentToRecipeVariables
+  >({
+    mutationFn: (variables: AddCommentToRecipeVariables) =>
+      fetchAddCommentToRecipe({ ...fetcherOptions, ...variables }),
+    ...options,
+  });
+};
+
+export type UpvoteCommentPathParams = {
+  recipeId: number;
+  commentId: number;
+};
+
+export type UpvoteCommentError = Fetcher.ErrorWrapper<{
+  status: 400;
+  payload: Responses.BadRequestResponse;
+}>;
+
+export type UpvoteCommentResponse = {
+  /**
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
+   *
+   * @example 200
+   * @example 201
+   */
+  status: 200 | 201;
+  data: Schemas.Comment;
+};
+
+export type UpvoteCommentVariables = {
+  pathParams: UpvoteCommentPathParams;
+} & SemanticBrowseContext["fetcherOptions"];
+
+export const fetchUpvoteComment = (
+  variables: UpvoteCommentVariables,
+  signal?: AbortSignal,
+) =>
+  semanticBrowseFetch<
+    UpvoteCommentResponse,
+    UpvoteCommentError,
+    undefined,
+    {},
+    {},
+    UpvoteCommentPathParams
+  >({
+    url: "/recipes/{recipeId}/comments/{commentId}/upvote",
+    method: "post",
+    ...variables,
+    signal,
+  });
+
+export const useUpvoteComment = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      UpvoteCommentResponse,
+      UpvoteCommentError,
+      UpvoteCommentVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useSemanticBrowseContext();
+  return reactQuery.useMutation<
+    UpvoteCommentResponse,
+    UpvoteCommentError,
+    UpvoteCommentVariables
+  >({
+    mutationFn: (variables: UpvoteCommentVariables) =>
+      fetchUpvoteComment({ ...fetcherOptions, ...variables }),
+    ...options,
+  });
+};
+
+export type RemoveUpvoteFromCommentPathParams = {
+  recipeId: number;
+  commentId: number;
+};
+
+export type RemoveUpvoteFromCommentError = Fetcher.ErrorWrapper<{
+  status: 400;
+  payload: Responses.BadRequestResponse;
+}>;
+
+export type RemoveUpvoteFromCommentResponse = {
+  /**
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
+   *
+   * @example 200
+   * @example 201
+   */
+  status: 200 | 201;
+  data: Schemas.Comment;
+};
+
+export type RemoveUpvoteFromCommentVariables = {
+  pathParams: RemoveUpvoteFromCommentPathParams;
+} & SemanticBrowseContext["fetcherOptions"];
+
+export const fetchRemoveUpvoteFromComment = (
+  variables: RemoveUpvoteFromCommentVariables,
+  signal?: AbortSignal,
+) =>
+  semanticBrowseFetch<
+    RemoveUpvoteFromCommentResponse,
+    RemoveUpvoteFromCommentError,
+    undefined,
+    {},
+    {},
+    RemoveUpvoteFromCommentPathParams
+  >({
+    url: "/recipes/{recipeId}/comments/{commentId}/upvote",
+    method: "delete",
+    ...variables,
+    signal,
+  });
+
+export const useRemoveUpvoteFromComment = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      RemoveUpvoteFromCommentResponse,
+      RemoveUpvoteFromCommentError,
+      RemoveUpvoteFromCommentVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useSemanticBrowseContext();
+  return reactQuery.useMutation<
+    RemoveUpvoteFromCommentResponse,
+    RemoveUpvoteFromCommentError,
+    RemoveUpvoteFromCommentVariables
+  >({
+    mutationFn: (variables: RemoveUpvoteFromCommentVariables) =>
+      fetchRemoveUpvoteFromComment({ ...fetcherOptions, ...variables }),
+    ...options,
+  });
+};
+
 export type GetFeedQueryParams = {
   type: "explore" | "following";
 };
@@ -1360,7 +1854,7 @@ export type GetFeedError = Fetcher.ErrorWrapper<{
 
 export type GetFeedResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -1449,6 +1943,16 @@ export type QueryOperation =
       path: "/recipes/{recipeId}";
       operationId: "getRecipeById";
       variables: GetRecipeByIdVariables;
+    }
+  | {
+      path: "/recipes/{recipeId}/bookmarks";
+      operationId: "getBookmarkers";
+      variables: GetBookmarkersVariables;
+    }
+  | {
+      path: "/recipes/{recipeId}/comments";
+      operationId: "getCommentsForRecipe";
+      variables: GetCommentsForRecipeVariables;
     }
   | {
       path: "/feed";

--- a/frontend/src/services/api/semanticBrowseResponses.ts
+++ b/frontend/src/services/api/semanticBrowseResponses.ts
@@ -12,7 +12,7 @@ export type OkResponse = Schemas.SuccessResponseObject;
  */
 export type CreatedResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -26,7 +26,7 @@ export type CreatedResponse = {
  */
 export type BadRequestResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 400
    * @example 401
@@ -44,7 +44,7 @@ export type BadRequestResponse = {
  */
 export type UnauthorizedResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 400
    * @example 401
@@ -62,7 +62,7 @@ export type UnauthorizedResponse = {
  */
 export type ForbiddenResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 400
    * @example 401
@@ -80,7 +80,7 @@ export type ForbiddenResponse = {
  */
 export type NotFoundResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 400
    * @example 401
@@ -98,7 +98,7 @@ export type NotFoundResponse = {
  */
 export type ConflictResponse = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 400
    * @example 401

--- a/frontend/src/services/api/semanticBrowseSchemas.ts
+++ b/frontend/src/services/api/semanticBrowseSchemas.ts
@@ -39,7 +39,7 @@ export type UserProfile = {
   diets?: string[];
   recipeCount?: number;
   /**
-   * Only available when querying own profile.
+   * Only available when querying the current user's profile.
    */
   bookmarks?: RecipeSummary[];
   recipes?: RecipeSummary[];
@@ -49,19 +49,19 @@ export type UserProfile = {
  * @example {"id":1,"username":"takoyaki_lover","name":"Takoyaki Lover","followersCount":100,"profilePicture":"http://commons.wikimedia.org/wiki/Special:FilePath/Takoyaki%20by%20yomi955.jpg","recipeCount":10,"avgRating":4.5}
  */
 export type UserSummary = {
-  id?: number;
-  username?: string;
-  name?: string;
-  followersCount?: number;
+  id: number;
+  username: string;
+  name: string;
+  followersCount: number;
   /**
    * @format uri
    */
-  profilePicture?: string;
-  recipeCount?: number;
+  profilePicture: string;
+  recipeCount: number;
   /**
    * @format float
    */
-  avgRating?: number;
+  avgRating: number;
 };
 
 /**
@@ -93,11 +93,12 @@ export type CuisineDetails = {
    * @format uri
    */
   image: string;
+  isSelfFollowing?: boolean;
   dishes?: DishSummary[];
 };
 
 /**
- * @example {"id":1,"name":"My Takoyaki Recipe","description":"A delicious takoyaki recipe that I learned from my grandmother.","cookTime":"30 minutes","images":["http://commons.wikimedia.org/wiki/Special:FilePath/Takoyaki%20by%20yomi955.jpg"],"rating":4.5,"dish":{"id":"http://www.wikidata.org/entity/Q905527","name":"takoyaki","image":"http://commons.wikimedia.org/wiki/Special:FilePath/Takoyaki%20by%20yomi955.jpg"},"author":{"id":1,"username":"takoyaki_lover","name":"Takoyaki Lover","followersCount":100,"profilePicture":"http://commons.wikimedia.org/wiki/Special:FilePath/Takoyaki%20by%20yomi955.jpg","recipeCount":10,"avgRating":4.5}}
+ * @example {"id":1,"name":"My Takoyaki Recipe","description":"A delicious takoyaki recipe that I learned from my grandmother.","cookTime":30,"images":["http://commons.wikimedia.org/wiki/Special:FilePath/Takoyaki%20by%20yomi955.jpg"],"avgRating":4.5,"ratingsCount":42,"selfRating":5,"dish":{"id":"http://www.wikidata.org/entity/Q905527","name":"takoyaki","image":"http://commons.wikimedia.org/wiki/Special:FilePath/Takoyaki%20by%20yomi955.jpg"},"author":{"id":1,"username":"takoyaki_lover","name":"Takoyaki Lover","followersCount":100,"profilePicture":"http://commons.wikimedia.org/wiki/Special:FilePath/Takoyaki%20by%20yomi955.jpg","recipeCount":10,"avgRating":4.5}}
  */
 export type RecipeSummary = {
   id: number;
@@ -106,12 +107,14 @@ export type RecipeSummary = {
   /**
    * Cook time in minutes
    */
-  cookTime?: number;
+  cookTime: number;
   images: string[];
   /**
    * @format float
    */
-  rating: number;
+  avgRating: number;
+  ratingsCount: number;
+  selfRating?: number;
   dish?: DishSummary;
   author: UserSummary;
 };
@@ -136,6 +139,10 @@ export type RecipeDetails = {
    */
   avgRating?: number;
   ratingsCount: number;
+  /**
+   * The current user's rating for this recipe, if any.
+   */
+  selfRating?: number;
   author: UserSummary;
 };
 
@@ -171,6 +178,39 @@ export type DishSummary = {
   name: string;
 };
 
+export type Comment = {
+  id: number;
+  author: UserSummary;
+  recipeId?: number;
+  upvoteCount: number;
+  content: string;
+  hasSelfUpvoted: boolean;
+  /**
+   * @format date-time
+   */
+  createdAt: string;
+};
+
+/**
+ * An array of comments
+ */
+export type CommentArray = Comment[];
+
+/**
+ * An array of dishes
+ */
+export type DishArray = DishDetails[];
+
+/**
+ * An array of recipes
+ */
+export type RecipeArray = RecipeDetails[];
+
+/**
+ * An array of users
+ */
+export type UserArray = UserSummary[];
+
 /**
  * @example {"status":200,"data":{"message":"Success"}}
  * @example {"status":400,"errors":[{"message":"Invalid email","field":"email"},{"message":"Invalid password","field":"password"}]}
@@ -190,7 +230,7 @@ export type ApiError = {
  */
 export type SuccessResponseObject = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 200
    * @example 201
@@ -204,7 +244,7 @@ export type SuccessResponseObject = {
  */
 export type ErrorResponseObject = {
   /**
-   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritive the inner status over the HTTP status.
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
    *
    * @example 400
    * @example 401
@@ -216,18 +256,3 @@ export type ErrorResponseObject = {
   status: 400 | 401 | 403 | 404 | 409 | 500;
   errors: ApiError[];
 };
-
-/**
- * An array of dishes
- */
-export type DishArray = DishDetails[];
-
-/**
- * An array of recipes
- */
-export type RecipeArray = RecipeDetails[];
-
-/**
- * An array of users
- */
-export type UserArray = UserSummary[];

--- a/swagger/openapi.yml
+++ b/swagger/openapi.yml
@@ -3,7 +3,7 @@ info:
   title: Semantic Cuisine
   description: |-
     This is the API specification for the Semantic Browse for Cuisines application.
-  version: 1.0.2
+  version: 1.0.3
 externalDocs:
   description: Refer to the requirements
   url: https://github.com/bounswe/bounswe2024group1/wiki/Requirements
@@ -256,6 +256,7 @@ paths:
       tags:
         - user
       summary: Update user profile
+      description: Can only update own profile
       security:
         - auth_jwt: []
       parameters:
@@ -284,6 +285,27 @@ paths:
                         $ref: "#/components/schemas/UserProfile"
         "404":
           $ref: "#/components/responses/NotFoundResponse"
+
+  /users/me:
+    get:
+      operationId: getMe
+      tags:
+        - user
+      summary: Get own profile
+      security:
+        - auth_jwt: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponseObject"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/UserProfile"
 
   /users/{userId}/following:
     get:
@@ -341,7 +363,7 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequestResponse"
 
-  /users/follow:
+  /users/{userId}/follow:
     post:
       operationId: followUser
       tags:
@@ -349,43 +371,53 @@ paths:
       summary: Follow a user
       security:
         - auth_jwt: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                followingUserId:
-                  type: integer
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: integer
       responses:
         "200":
-          $ref: "#/components/responses/OkResponse"
+          description: OK - returning new user profile
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponseObject"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/UserProfile"
         "400":
           $ref: "#/components/responses/BadRequestResponse"
         "404":
           $ref: "#/components/responses/NotFoundResponse"
-
-  /users/unfollow:
-    post:
+    delete:
       operationId: unfollowUser
       tags:
         - user
       summary: Unfollow a user
       security:
         - auth_jwt: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                followingUserId:
-                  type: integer
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: integer
       responses:
         "200":
-          $ref: "#/components/responses/OkResponse"
+          description: OK - returning new user profile
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponseObject"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/UserProfile"
         "400":
           $ref: "#/components/responses/BadRequestResponse"
         "404":
@@ -508,6 +540,36 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/CuisineDetails"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+  /cuisines/{cuisineId}/follow:
+    post:
+      operationId: followCuisine
+      tags:
+        - cuisines
+      summary: Follow a cuisine
+      security:
+        - auth_jwt: []
+      parameters:
+        - in: path
+          name: cuisineId
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK - returning cuisine details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponseObject"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/CuisineDetails"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
         "404":
           $ref: "#/components/responses/NotFoundResponse"
 
@@ -654,7 +716,32 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequestResponse"
 
-  /recipes/{recipeId}/bookmark:
+  /recipes/{recipeId}/bookmarks:
+    get:
+      operationId: getBookmarkers
+      tags:
+        - recipe
+      summary: Get users who bookmarked a recipe
+      parameters:
+        - in: path
+          name: recipeId
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponseObject"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/UserArray"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
     post:
       operationId: bookmarkRecipe
       tags:
@@ -671,6 +758,153 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/OkResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+    delete:
+      operationId: unbookmarkRecipe
+      tags:
+        - recipe
+      summary: Unbookmark a recipe
+      security:
+        - auth_jwt: []
+      parameters:
+        - in: path
+          name: recipeId
+          required: true
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: OK
+          $ref: "#/components/responses/OkResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+  /recipes/{recipeId}/comments:
+    get:
+      operationId: getCommentsForRecipe
+      tags:
+        - recipe
+      summary: Get comments for a recipe
+      parameters:
+        - in: path
+          name: recipeId
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponseObject"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/CommentArray"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+    post:
+      operationId: addCommentToRecipe
+      tags:
+        - recipe
+      summary: Add a comment to a recipe
+      security:
+        - auth_jwt: []
+      parameters:
+        - in: path
+          name: recipeId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                comment:
+                  type: string
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponseObject"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/Comment"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+
+  /recipes/{recipeId}/comments/{commentId}/upvote:
+    post:
+      operationId: upvoteComment
+      tags:
+        - recipe
+      summary: Upvote a comment
+      security:
+        - auth_jwt: []
+      parameters:
+        - in: path
+          name: recipeId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: commentId
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK - returns new comment after upvote
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponseObject"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/Comment"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+    delete:
+      operationId: removeUpvoteFromComment
+      tags:
+        - recipe
+      summary: Remove upvote from a comment
+      security:
+        - auth_jwt: []
+      parameters:
+        - in: path
+          name: recipeId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: commentId
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK - returns new comment after upvote removal
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponseObject"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/Comment"
         "400":
           $ref: "#/components/responses/BadRequestResponse"
 
@@ -775,7 +1009,7 @@ components:
           type: integer
         bookmarks:
           type: array
-          description: Only available when querying own profile.
+          description: Only available when querying the current user's profile.
           items:
             $ref: "#/components/schemas/RecipeSummary"
         recipes:
@@ -816,6 +1050,14 @@ components:
                 name: "takoyaki"
     UserSummary:
       type: object
+      required:
+        - id
+        - username
+        - name
+        - followersCount
+        - profilePicture
+        - recipeCount
+        - avgRating
       properties:
         id:
           type: integer
@@ -900,6 +1142,8 @@ components:
         image:
           type: string
           format: uri
+        isSelfFollowing:
+          type: boolean
         dishes:
           type: array
           items:
@@ -913,6 +1157,9 @@ components:
         - description
         - images
         - rating
+        - cookTime
+        - avgRating
+        - ratingsCount
         - author
       properties:
         id:
@@ -929,9 +1176,13 @@ components:
           items:
             type: string
             format: uri
-        rating:
+        avgRating:
           type: number
           format: float
+        ratingsCount:
+          type: integer
+        selfRating:
+          type: integer
         dish:
           $ref: "#/components/schemas/DishSummary"
         author:
@@ -940,10 +1191,12 @@ components:
         - id: 1
           name: "My Takoyaki Recipe"
           description: "A delicious takoyaki recipe that I learned from my grandmother."
-          cookTime: "30 minutes"
+          cookTime: 30
           images:
             - "http://commons.wikimedia.org/wiki/Special:FilePath/Takoyaki%20by%20yomi955.jpg"
-          rating: 4.5
+          avgRating: 4.5
+          ratingsCount: 42
+          selfRating: 5
           dish:
             id: "http://www.wikidata.org/entity/Q905527"
             name: "takoyaki"
@@ -1008,6 +1261,9 @@ components:
           format: float
         ratingsCount:
           type: integer
+        selfRating:
+          type: integer
+          description: The current user's rating for this recipe, if any.
         author:
           $ref: "#/components/schemas/UserSummary"
       examples:
@@ -1127,6 +1383,56 @@ components:
         - id: 1
           name: "takoyaki"
 
+    Comment:
+      type: object
+      required:
+        - id
+        - author
+        - content
+        - upvoteCount
+        - hasSelfUpvoted
+        - createdAt
+      properties:
+        id:
+          type: integer
+        author:
+          $ref: "#/components/schemas/UserSummary"
+        recipeId:
+          type: integer
+        upvoteCount:
+          type: integer
+        content:
+          type: string
+        hasSelfUpvoted:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+
+    CommentArray:
+      description: An array of comments
+      type: array
+      items:
+        $ref: "#/components/schemas/Comment"
+
+    DishArray:
+      description: An array of dishes
+      type: array
+      items:
+        $ref: "#/components/schemas/DishDetails"
+
+    RecipeArray:
+      description: An array of recipes
+      type: array
+      items:
+        $ref: "#/components/schemas/RecipeDetails"
+
+    UserArray:
+      description: An array of users
+      type: array
+      items:
+        $ref: "#/components/schemas/UserSummary"
+
     ApiResponse:
       oneOf:
         - $ref: "#/components/schemas/SuccessResponseObject"
@@ -1160,7 +1466,7 @@ components:
           type: integer
           description:
             Internal status code of the response. An HTTP 200 response with an internal
-            500 status code is an error response. Prioritive the inner status over the HTTP
+            500 status code is an error response. Prioritize the inner status over the HTTP
             status.
           enum:
             - 200
@@ -1185,28 +1491,13 @@ components:
             - 500
           description:
             Internal status code of the response. An HTTP 200 response with an internal
-            500 status code is an error response. Prioritive the inner status over the HTTP
+            500 status code is an error response. Prioritize the inner status over the HTTP
             status.
           examples: [400, 401, 403, 404, 409, 500]
         errors:
           type: array
           items:
             $ref: "#/components/schemas/ApiError"
-    DishArray:
-      description: An array of dishes
-      type: array
-      items:
-        $ref: "#/components/schemas/DishDetails"
-    RecipeArray:
-      description: An array of recipes
-      type: array
-      items:
-        $ref: "#/components/schemas/RecipeDetails"
-    UserArray:
-      description: An array of users
-      type: array
-      items:
-        $ref: "#/components/schemas/UserSummary"
   responses:
     OkResponse:
       description: OK


### PR DESCRIPTION
This pull request updates the OpenAPI specification to version 1.0.3 to align with the latest requirements. The changes include:
## User endpoints:

Added `/users/me` endpoint to get the current user's profile
Changed `/users/follow` and `/users/unfollow` to `POST /users/{userId}/follow` and `DELETE /users/{userId}/follow` for better REST semantics
Updated `/users/{userId}` response to include isSelfFollowing boolean

## Cuisine endpoints:

Added `POST /cuisines/{cuisineId}/follow` endpoint to follow a cuisine

## Recipe endpoints:

Added `GET /recipes/{recipeId}/bookmarks` to get users who bookmarked a recipe
Changed `/recipes/{recipeId}/bookmark` to also support `DELETE` to unbookmark
Added comment endpoints:

`GET /recipes/{recipeId}/comments` to get comments
`POST /recipes/{recipeId}/comments` to add a comment
`POST /recipes/{recipeId}/comments/{commentId}/upvote` to upvote a comment
`DELETE /recipes/{recipeId}/comments/{commentId}/upvote` to remove an upvote


Updated recipe responses to include `avgRating`, `ratingsCount` and `selfRating`

## Schema changes:

Added `Comment` and `CommentArray` schemas
Made some recipe and user summary fields required
Added `hasSelfUpvoted` to Comment schema
Clarified that bookmarks are only returned for current user

## Other:

Fixed some typos in API response descriptions
Improved naming consistency for array schemas

Please review and merge these changes to keep the API specification in sync with our evolving requirements. Let me know if any adjustments are needed!

Resolves #116 