### PR TITLE
feature(frontend): add react-hook-form to login and signup forms

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -22,5 +22,6 @@ module.exports = {
       "off",
       { allowConstantExport: true },
     ],
+    "@typescript-eslint/no-unused-vars": ["warn"],
   },
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,8 @@
     "generate:api": "openapi-codegen gen semanticBrowse"
   },
   "dependencies": {
+    "@hookform/error-message": "^2.0.1",
+    "@hookform/resolvers": "^3.3.4",
     "@radix-ui/react-aspect-ratio": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
@@ -32,10 +34,11 @@
     "lucide-react": "^0.376.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.51.4",
     "react-router-dom": "^6.23.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.23.5",
+    "zod": "^3.23.7",
     "zustand": "^4.5.2"
   },
   "devDependencies": {
@@ -62,7 +65,6 @@
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.14",
-    "react-query-swagger": "^15.11.1",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
@@ -72,8 +74,14 @@
     "pre-commit": "lint-staged && tsc"
   },
   "lint-staged": {
-    "*/**/*.{js,jsx,ts,tsx}": ["prettier --write", "eslint --fix", "eslint"],
-    "*/**/*.{json,css,md}": ["prettier --write"]
+    "*/**/*.{js,jsx,ts,tsx}": [
+      "prettier --write",
+      "eslint --fix",
+      "eslint"
+    ],
+    "*/**/*.{json,css,md}": [
+      "prettier --write"
+    ]
   },
   "packageManager": "yarn@4.1.1"
 }

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -1,0 +1,177 @@
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue,
+);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>");
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue,
+);
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  );
+});
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField();
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+});
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField();
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+});
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message) : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-sm font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+});
+FormMessage.displayName = "FormMessage";
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+};

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { RouteObject, redirect } from "react-router-dom";
-import Login, { action as loginAction } from "./login";
-import Signup, { action as signupAction } from "./signup";
+import Login from "./login";
+import Signup from "./signup";
 import { IndexRoute } from "./home";
 import { signout } from "../services/auth";
 import { Search } from "./search";
@@ -10,11 +10,9 @@ export const routes: RouteObject[] = [
   {
     path: "/login",
     Component: Login,
-    action: loginAction,
   },
   {
     path: "/signup",
-    action: signupAction,
     Component: Signup,
   },
   {

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -1,13 +1,4 @@
-import {
-  ActionFunctionArgs,
-  Form,
-  Link,
-  Navigate,
-  redirect,
-  useActionData,
-  useLocation,
-  useNavigation,
-} from "react-router-dom";
+import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -18,15 +9,24 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { z } from "zod";
 import useAuthStore from "../services/auth";
 import { fetchSignup } from "../services/api/semanticBrowseComponents";
 import {
   FetchError,
-  getFieldErrors,
-  renderError,
+  setFormErrors,
 } from "../services/api/semanticBrowseFetcher";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "../components/ui/form";
 
 const signupSchema = z.object({
   firstName: z.string().min(1),
@@ -35,49 +35,10 @@ const signupSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
   country: z.string().min(1),
+  redirectTo: z.string().optional(),
 });
 
-export const action = async ({
-  request,
-}: ActionFunctionArgs): Promise<
-  z.inferFlattenedErrors<typeof signupSchema> | Response
-> => {
-  const formData = await request.formData();
-
-  const email = formData.get("email") as string | null;
-  const password = formData.get("password") as string | null;
-  const username = formData.get("username") as string | null;
-  const firstName = formData.get("firstName") as string | null;
-  const lastName = formData.get("lastName") as string | null;
-  const country = formData.get("country") as string | null;
-
-  const parsed = signupSchema.safeParse({
-    email,
-    password,
-    username,
-    firstName,
-    lastName,
-    country,
-  });
-
-  if (!parsed.success) {
-    return parsed.error.flatten();
-  }
-
-  try {
-    await fetchSignup({
-      body: parsed.data,
-    });
-  } catch (error) {
-    return {
-      formErrors: [renderError(error as FetchError)],
-      fieldErrors: getFieldErrors(error as FetchError),
-    };
-  }
-
-  const redirectTo = formData.get("redirectTo") as string | null;
-  return redirect(redirectTo || "/");
-};
+type SignupFormData = z.infer<typeof signupSchema>;
 
 export default function Signup() {
   const location = useLocation();
@@ -86,21 +47,39 @@ export default function Signup() {
 
   const auth = useAuthStore();
 
-  const navigation = useNavigation();
-  const isSigningUp = !!navigation.formData?.get("email");
+  const form = useForm<SignupFormData>({
+    defaultValues: {
+      redirectTo: from,
+      country: "",
+      email: "",
+      firstName: "",
+      lastName: "",
+      password: "",
+    },
+    resolver: zodResolver(signupSchema),
+  });
 
-  const actionData = useActionData() as
-    | Exclude<Awaited<ReturnType<typeof action>>, Response>
-    | undefined;
+  const {
+    handleSubmit,
+    setError,
+    control,
+    formState: { isSubmitting },
+  } = form;
 
-  function getErrorLabel(field: keyof z.infer<typeof signupSchema>) {
-    return actionData && actionData.fieldErrors[field] ? (
-      <div className="text-sm text-red-500">
-        {actionData.fieldErrors[field]!.join("\n")}
-      </div>
-    ) : null;
-  }
-
+  const navigate = useNavigate();
+  const submit: SubmitHandler<SignupFormData> = async ({
+    redirectTo,
+    ...data
+  }): Promise<void> => {
+    try {
+      await fetchSignup({
+        body: data,
+      });
+      if (redirectTo) navigate(redirectTo);
+    } catch (e) {
+      setFormErrors(e as FetchError, setError);
+    }
+  };
   return (
     <div className="flex flex-1 items-center justify-center">
       <Card className="mx-auto max-w-sm">
@@ -112,64 +91,138 @@ export default function Signup() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <Form method="POST" className="grid gap-4">
-            <input type="hidden" name="redirectTo" value={from} />
-            <div className="grid grid-cols-2 gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="first-name">First name</Label>
-                <Input
-                  name="firstName"
-                  id="first-name"
-                  placeholder="Max"
-                  required
-                />
-                {getErrorLabel("firstName")}
+          <Form {...form}>
+            <form onSubmit={handleSubmit(submit)} className="grid gap-4">
+              <input type="hidden" name="redirectTo" value={from} />
+              <div className="grid grid-cols-2 gap-4">
+                <div className="grid gap-2">
+                  <FormField
+                    control={control}
+                    name="firstName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>First name </FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="John"
+                            autoComplete="given-name"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <FormField
+                    control={control}
+                    name="lastName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Last name </FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="Doe"
+                            autoComplete="family-name"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="last-name">Last name</Label>
-                <Input
-                  name="lastName"
-                  id="last-name"
-                  placeholder="Robinson"
-                  required
+                <FormField
+                  control={control}
+                  name="username"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Username </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="john_doe"
+                          autoComplete="username"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-                {getErrorLabel("lastName")}
               </div>
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="username">Username</Label>
-              <Input name="username" id="username" type="username" />
-              {getErrorLabel("username")}
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                name="email"
-                placeholder="m@example.com"
-                required
+              <div className="grid gap-2">
+                <FormField
+                  control={control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Email </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="m@example.com"
+                          type="email"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className="grid gap-2">
+                <FormField
+                  control={control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Password</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="password"
+                          autoComplete="current-password"
+                          type="password"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className="grid gap-2">
+                <FormField
+                  control={control}
+                  name="country"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Country</FormLabel>
+                      <FormControl>
+                        <Input
+                          autoComplete="country"
+                          placeholder="TR"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Please enter your country code
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                name="root.serverError"
+                render={() => <FormMessage />}
               />
-              {getErrorLabel("email")}
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="password">Password</Label>
-              <Input name="password" id="password" type="password" />
-              {getErrorLabel("password")}
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="country">Country</Label>
-              <Input name="country" id="country" type="country" />
-              {getErrorLabel("country")}
-            </div>
-            {actionData && actionData.formErrors ? (
-              <div className="text-sm text-red-500">
-                {actionData.formErrors.join("\n")}
-              </div>
-            ) : null}
-            <Button loading={isSigningUp} type="submit" className="w-full">
-              Create an account
-            </Button>
+              <Button loading={isSubmitting} type="submit" className="w-full">
+                Create an account
+              </Button>
+            </form>
           </Form>
           <div className="mt-4 text-center text-sm">
             Already have an account?{" "}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -394,6 +394,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hookform/error-message@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@hookform/error-message@npm:2.0.1"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+    react-hook-form: ^7.0.0
+  checksum: 10c0/6b608bcdbd797ddb7c6cfc8c42b6bbac40066181a0c582b1f1a342bfa65fa7e8329cdb8e869a76e33988cd46fe8623d521ea597231b9d33e1f0ba3288e36c58e
+  languageName: node
+  linkType: hard
+
+"@hookform/resolvers@npm:^3.3.4":
+  version: 3.3.4
+  resolution: "@hookform/resolvers@npm:3.3.4"
+  peerDependencies:
+    react-hook-form: ^7.0.0
+  checksum: 10c0/f7a5b8ba59cbb0859e7a212bd5cbcbc70bbdddd21d4fbe9f4a96d149b5756470cb29857a50334d8c1c64392e21007ccf5288d26aa407431784d4006a2570cb36
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.14":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
@@ -3776,6 +3796,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "frontend@workspace:."
   dependencies:
+    "@hookform/error-message": "npm:^2.0.1"
+    "@hookform/resolvers": "npm:^3.3.4"
     "@openapi-codegen/cli": "npm:^2.0.2"
     "@openapi-codegen/typescript": "npm:^8.0.2"
     "@radix-ui/react-aspect-ratio": "npm:^1.0.3"
@@ -3813,7 +3835,7 @@ __metadata:
     prettier-plugin-tailwindcss: "npm:^0.5.14"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
-    react-query-swagger: "npm:^15.11.1"
+    react-hook-form: "npm:^7.51.4"
     react-router-dom: "npm:^6.23.0"
     tailwind-merge: "npm:^2.3.0"
     tailwindcss: "npm:^3.4.3"
@@ -3821,7 +3843,7 @@ __metadata:
     typescript: "npm:^5.2.2"
     vite: "npm:^5.2.0"
     vitest: "npm:^1.5.2"
-    zod: "npm:^3.23.5"
+    zod: "npm:^3.23.7"
     zustand: "npm:^4.5.2"
   languageName: unknown
   linkType: soft
@@ -5381,15 +5403,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nswag-portable@npm:13.20.0-v.17":
-  version: 13.20.0-v.17
-  resolution: "nswag-portable@npm:13.20.0-v.17"
-  bin:
-    nswag-portable: nswag-portable.js
-  checksum: 10c0/ee140d8e29748796999bfa829b879fc182a3c01141e12407024467f235d9626ecc0d5042b7029ec2fb57493d91dba4ff6730706de1b11170f9d1e3ef7313788a
-  languageName: node
-  linkType: hard
-
 "nwsapi@npm:^2.2.7":
   version: 2.2.9
   resolution: "nwsapi@npm:2.2.9"
@@ -6077,6 +6090,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-hook-form@npm:^7.51.4":
+  version: 7.51.4
+  resolution: "react-hook-form@npm:7.51.4"
+  peerDependencies:
+    react: ^16.8.0 || ^17 || ^18
+  checksum: 10c0/73b585adb80bd99ae1fc21208e389fd9830f82c8c8bab4b6c4d5853f858a3259b8dc8fd4aa4608a0bd95bc69883c9332f2fa5e8c80dc17dbb2866de9744dbdb6
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -6095,23 +6117,6 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
-  languageName: node
-  linkType: hard
-
-"react-query-swagger@npm:^15.11.1":
-  version: 15.11.1
-  resolution: "react-query-swagger@npm:15.11.1"
-  dependencies:
-    nswag-portable: "npm:13.20.0-v.17"
-  peerDependencies:
-    "@tanstack/react-query": "> 4.0"
-    "@tanstack/react-query-persist-client": ">4.2.0"
-    react: 17.x || 18.x
-    react-query: ">= 3.33 < 4.0"
-    typescript: "> 3.0"
-  bin:
-    react-query-swagger: cli.js
-  checksum: 10c0/f40917f7e32204ddbca377bcb9698918e0f19bb3ed231716e56467d8185a8c525b0985b5ed7ac4af56d6dcee55d48fa851e910dba124a33ddb3cd7f9075e0503
   languageName: node
   linkType: hard
 
@@ -7941,10 +7946,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.23.5":
-  version: 3.23.5
-  resolution: "zod@npm:3.23.5"
-  checksum: 10c0/5c74aefe2c0bc2f00d79c5a8724dae863054653bbad640964fdb009c52573349366fa70533f0dfcb912b007421294d437f063d466f9692eb77a2b620640c2794
+"zod@npm:^3.23.7":
+  version: 3.23.7
+  resolution: "zod@npm:3.23.7"
+  checksum: 10c0/c746d8882d4797597c945fea293dc69caba6de90b82037ca8ee8a1acaea8c5f8ce73492b4a5fac3100a11a99807737b2fcd51db93d9e9ca4d6b938faed67b6e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add error handler compatible with our API spec.
Migrated login and signup forms to react-hook-form. Removed react-query-swagger which was not used.
Resolves #141 