### PR TITLE
feat(devops): add mock s3 service

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -2,6 +2,17 @@ name: bounswe2024group1
 # Production-like docker-compose setup
 
 services:
+  s3mock:
+    image: adobe/s3mock:latest
+    environment:
+      - retainFilesOnExit=true
+      - initialBuckets=cuisines
+      - root=containers3root
+    ports:
+      - 9090:9090
+      - 9191:9191
+    volumes:
+      - s3mock-files:/containers3root
   swagger:
     image: swaggerapi/swagger-ui
     environment:
@@ -45,3 +56,4 @@ services:
 
 volumes:
   db-data:
+  s3mock-files:

--- a/compose.yml
+++ b/compose.yml
@@ -39,6 +39,10 @@ services:
       DB_USER: root
       DB_PASSWORD: admin
       SPRING_PROFILES_ACTIVE: docker
+      DO_SPACES_ENDPOINT: "http://s3mock:9090"
+      DO_SPACES_ACCESS_KEY: "---"
+      DO_SPACES_SECRET_KEY: "---"
+      DO_SPACES_BUCKET: "cuisines"
     depends_on:
       - db
   web:

--- a/dev.yml
+++ b/dev.yml
@@ -1,6 +1,10 @@
 name: bounswe2024group1-dev
 
 services:
+  s3mock:
+    extends:
+      file: compose.yml
+      service: s3mock
   swagger:
     extends:
       file: compose.yml
@@ -24,6 +28,10 @@ services:
       DB_USER: root
       DB_PASSWORD: admin
       SPRING_PROFILES_ACTIVE: docker
+      DO_SPACES_ENDPOINT: "http://s3mock:9090"
+      DO_SPACES_ACCESS_KEY: "minioadmin"
+      DO_SPACES_SECRET_KEY: "minioadmin"
+      DO_SPACES_BUCKET: "cuisines"
     depends_on:
       - db
   web:
@@ -46,3 +54,4 @@ services:
 volumes:
   node_modules:
   db-data:
+  s3mock-files:

--- a/dev.yml
+++ b/dev.yml
@@ -29,8 +29,8 @@ services:
       DB_PASSWORD: admin
       SPRING_PROFILES_ACTIVE: docker
       DO_SPACES_ENDPOINT: "http://s3mock:9090"
-      DO_SPACES_ACCESS_KEY: "minioadmin"
-      DO_SPACES_SECRET_KEY: "minioadmin"
+      DO_SPACES_ACCESS_KEY: "---"
+      DO_SPACES_SECRET_KEY: "---"
       DO_SPACES_BUCKET: "cuisines"
     depends_on:
       - db


### PR DESCRIPTION
Added an s3mock service to both prod and development docker compose setups.
Make sure that you use it with path-style endpoints. This requires extra configuration. More info [here](https://github.com/adobe/S3Mock?tab=readme-ov-file#path-style-vs-domain-style-access)