### PR TITLE
Implemented users/{userId}/unfollow DELETE endpoint

### DIFF
--- a/backend/src/main/java/com/group1/programminglanguagesforum/Constants/EndpointConstants.java
+++ b/backend/src/main/java/com/group1/programminglanguagesforum/Constants/EndpointConstants.java
@@ -11,5 +11,6 @@ public  class EndpointConstants {
         public static final String USER_ME = BASE_PATH + "/me";
         public static final String USER_ID = BASE_PATH + "/{id}";
         public static final String USER_FOLLOW = BASE_PATH + "/{id}/follow";
+        public static final String USER_UNFOLLOW = BASE_PATH + "/{id}/unfollow";
     }
 }

--- a/backend/src/main/java/com/group1/programminglanguagesforum/Controllers/UserController.java
+++ b/backend/src/main/java/com/group1/programminglanguagesforum/Controllers/UserController.java
@@ -187,5 +187,46 @@ public class UserController extends BaseController {
 
     }
 
+    @DeleteMapping(value = EndpointConstants.UserEndpoints.USER_UNFOLLOW)
+    public ResponseEntity<GenericApiResponse<UserProfileResponseDto>> unfollowUser(@PathVariable(name = "id")Long id){
+        try{
+            User user = userContextService.getCurrentUser();
+            User unfollowedUser = userService.unfollowUser(user, id);
+            UserProfileResponseDto updatedUserProfileResponseDto = modelMapper.map(unfollowedUser, UserProfileResponseDto.class);
+            GenericApiResponse<UserProfileResponseDto> response = ApiResponseBuilder.buildSuccessResponse(
+                    updatedUserProfileResponseDto.getClass(),
+                    "User unfollowed successfully",
+                    HttpStatus.OK.value(),
+                    updatedUserProfileResponseDto
+
+            );
+            return buildResponse(response, HttpStatus.valueOf(response.getStatus()));
+        } catch (UnauthorizedAccessException  e) {
+            ErrorResponse errorResponse = ErrorResponse.builder()
+                    .errorMessage(e.getMessage())
+                    .stackTrace(Arrays.toString(e.getStackTrace()))
+                    .build();
+            GenericApiResponse<UserProfileResponseDto> response = ApiResponseBuilder.buildErrorResponse(
+                    UserProfileResponseDto.class,
+                    e.getMessage(),
+                    HttpStatus.UNAUTHORIZED.value(),
+                    errorResponse
+            );
+            return buildResponse(response, HttpStatus.valueOf(response.getStatus()));
+        } catch (UserNotFoundException e) {
+            ErrorResponse errorResponse = ErrorResponse.builder()
+                    .errorMessage(e.getMessage())
+                    .stackTrace(Arrays.toString(e.getStackTrace()))
+                    .build();
+            GenericApiResponse<UserProfileResponseDto> response = ApiResponseBuilder.buildErrorResponse(
+                    UserProfileResponseDto.class,
+                    e.getMessage(),
+                    HttpStatus.NOT_FOUND.value(),
+                    errorResponse
+            );
+            return buildResponse(response, HttpStatus.valueOf(response.getStatus()));
+        }
+    }
+
 }
 

--- a/backend/src/main/java/com/group1/programminglanguagesforum/Services/UserService.java
+++ b/backend/src/main/java/com/group1/programminglanguagesforum/Services/UserService.java
@@ -43,4 +43,18 @@ public class UserService {
         userToFollow.setFollowersCount(userToFollow.getFollowersCount() + 1);
         return userRepository.save(userToFollow);
     }
+    @Transactional
+    public User unfollowUser(User user, Long id) throws UserNotFoundException {
+        Optional<User> userToUnfollowOptional = userRepository.findById(id);
+        if (userToUnfollowOptional.isEmpty()) {
+            throw new UserNotFoundException("User not found");
+        }
+        User userToUnfollow = userToUnfollowOptional.get();
+        user.getFollowing().remove(userToUnfollow);
+        user.setFollowingCount(user.getFollowingCount() - 1);
+        userRepository.save(user);
+        userToUnfollow.getFollowers().remove(user);
+        userToUnfollow.setFollowersCount(userToUnfollow.getFollowersCount() - 1);
+        return userRepository.save(userToUnfollow);
+    }
 }


### PR DESCRIPTION
## 📋 Proposed Changes

  - Implemented users/{userId}/unfollow DELETE endpoint

## Related Issue
Closes #398 

## 🧪 Included Tests
- [x] A registered user can unfollow another user which is followed previously.
