### PR TITLE
Create Queries for Software Library and Computer Science Term 

### DIFF
--- a/backend/src/main/java/com/group1/programminglanguagesforum/Constants/GeneralConstants.java
+++ b/backend/src/main/java/com/group1/programminglanguagesforum/Constants/GeneralConstants.java
@@ -3,6 +3,40 @@ package com.group1.programminglanguagesforum.Constants;
 public class GeneralConstants {
     public static class SparqlConstants {
         public static final String USER_AGENT = "Wikidata RDF4J Java Example/0.1 (https://query.wikidata.org/)";
+        public static final String SOFTWARE_LIBRARY_QUERY = """
+                        SELECT DISTINCT ?library
+                        (SAMPLE(?libraryLabel) AS ?libraryLabelS)\s
+                        (SAMPLE(?description) AS ?descriptionS)\s
+                        (SAMPLE(?logoImage) AS ?logoImageS)\s
+                        (SAMPLE(?officialWebSite) AS ?officialWebSiteS)\s
+                        (SAMPLE(?stackExchangeTag) AS ?stackExchangeTagS)
+                    WHERE {
+                        ?library wdt:P31 wd:Q188860.  
+                        
+                        FILTER (
+                            EXISTS { ?library wdt:P154 ?logoImage }
+                        )
+                        FILTER (
+                            EXISTS { ?library wdt:P856 ?officialWebSite }
+                        )
+
+                        OPTIONAL { ?library wdt:P154 ?logoImage }
+                        OPTIONAL { ?library wdt:P856 ?officialWebSite }
+                        OPTIONAL { ?library wdt:P1482 ?stackExchangeTag }
+
+                        OPTIONAL {
+                            ?library schema:description ?description.
+                            FILTER((LANG(?description)) = "en")\s
+                        }
+                        OPTIONAL {
+                            ?library rdfs:label ?libraryLabel.
+                            FILTER((LANG(?libraryLabel)) = "en")\s
+                        }
+                    }
+                    GROUP BY ?library
+                    HAVING (BOUND(?libraryLabelS))
+                """;
+        
         public static final String PROGRAMMING_PARADIGM_QUERY = """
                  SELECT DISTINCT ?paradigm\s
                             (SAMPLE(?paradigmLabel) AS ?paradigmLabelS)\s
@@ -29,6 +63,32 @@ public class GeneralConstants {
                         GROUP BY ?paradigm
                         HAVING (BOUND(?paradigmLabelS))\
                 """;
+        public static final String COMPUTER_SCIENCE_TERM_QUERY = """
+                    SELECT DISTINCT ?term\s
+                               (SAMPLE(?termLabel) AS ?termLabelS)\s
+                               (SAMPLE(?description) AS ?descriptionS)\s
+                               (SAMPLE(?stackExchangeTag) AS ?stackExchangeTagS)
+   
+                           WHERE {
+                               ?term wdt:P31 wd:Q66747126.
+   
+                               OPTIONAL {
+                                   ?term schema:description ?description.
+                                   FILTER((LANG(?description)) = "en")\s
+                               }
+   
+                               OPTIONAL {
+                                   ?term rdfs:label ?termLabel.
+                                   FILTER((LANG(?termLabel)) = "en")\s
+                               }
+   
+                               OPTIONAL {
+                                   ?term wdt:P1482 ?stackExchangeTag.\s
+                               }
+                           }
+                           GROUP BY ?term
+                           HAVING (BOUND(?termLabelS))\
+                   """;
         public static final String PROGRAMMING_LANGUAGES_QUERY =
                 """
                         SELECT DISTINCT ?language\s
@@ -39,7 +99,7 @@ public class GeneralConstants {
                             (SAMPLE(?inceptionYear) AS ?inceptionYearS)
                             (SAMPLE(?fileExtension) AS ?fileExtensionS)
                             (SAMPLE(?officialWebSite) AS ?officialWebSiteS)
-                        (SAMPLE(?stackExchangeTag) AS ?stackExchangeTagS)
+                            (SAMPLE(?stackExchangeTag) AS ?stackExchangeTagS)
                         WHERE {
                             {
                                 ?language wdt:P31 wd:Q9143.  # programming language

--- a/backend/src/main/java/com/group1/programminglanguagesforum/Entities/ComputerScienceTermTag.java
+++ b/backend/src/main/java/com/group1/programminglanguagesforum/Entities/ComputerScienceTermTag.java
@@ -1,0 +1,13 @@
+package com.group1.programminglanguagesforum.Entities;
+import jakarta.persistence.Entity;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Entity
+public class ComputerScienceTermTag extends Tag{
+    private String stackExchangeTag;
+}

--- a/backend/src/main/java/com/group1/programminglanguagesforum/Entities/SoftwareLibraryTag.java
+++ b/backend/src/main/java/com/group1/programminglanguagesforum/Entities/SoftwareLibraryTag.java
@@ -1,0 +1,15 @@
+package com.group1.programminglanguagesforum.Entities;
+import jakarta.persistence.Entity;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Entity
+public class SoftwareLibraryTag extends Tag{
+    private String logoImage;
+    private String officialWebsite;
+    private String stackExchangeTag;
+}


### PR DESCRIPTION

## 📋 Proposed Changes

Wrote the SPARQL queries to retrieve data for Software Library and Computer Science Term
The queries were tested in Wikidata Query Service to retrieve the necessary information for both entities.

## Related Issue
Closes #460 and #461

## 🧪 Included Tests
- [ ] All related information is retrieved
