### PR TITLE
[FE/Mobile] Synchronize API schema

### DIFF
--- a/backend/src/main/java/com/group1/programminglanguagesforum/Services/JwtService.java
+++ b/backend/src/main/java/com/group1/programminglanguagesforum/Services/JwtService.java
@@ -58,7 +58,7 @@ public class JwtService {
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(
-                        new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2))
+                        new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(24))
                 )
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();

--- a/frontend/src/components/HighlightedQuestionCard.tsx
+++ b/frontend/src/components/HighlightedQuestionCard.tsx
@@ -1,28 +1,16 @@
 import { Card } from "@/components/ui/card";
+import { QuestionSummary } from "@/services/api/programmingForumSchemas";
 
 import { ArrowRight, MessageSquare, Star } from "lucide-react";
 import React from "react";
 import { Link } from "react-router-dom";
 
-interface HighlightedQuestionCardProps {
-  id: number;
-  title: string;
-  content: string;
-  votes: number;
-  answerCount: number;
-  author: {
-    id: number;
-    name: string;
-    profilePicture: string;
-  };
-}
-
-export const HighlightedQuestionCard: React.FC<HighlightedQuestionCardProps> = ({
+export const HighlightedQuestionCard: React.FC<Partial<QuestionSummary>> = ({
   id,
   title,
-  content,
-  votes,
-  answerCount,
+  questionBody,
+  likeCount,
+  commentCount,
   author,
 }) => {
   return (
@@ -32,26 +20,28 @@ export const HighlightedQuestionCard: React.FC<HighlightedQuestionCardProps> = (
           {title}
         </h3>
         <p className="line-clamp-3 text-sm font-light text-gray-800">
-          {content}
+          {questionBody}
         </p>
         <div className="flex flex-col gap-3 text-xs text-gray-700">
           <div className="flex items-center gap-1">
             <Star className="h-4 w-4" />
-            <span>{votes} votes</span>
+            <span>{likeCount} votes</span>
           </div>
           <div className="flex items-center gap-1">
-            <MessageSquare className="h-4 w-4"/>
-            <span>{answerCount} answers</span>
+            <MessageSquare className="h-4 w-4" />
+            <span>{commentCount} answers</span>
           </div>
         </div>
         <div className="flex items-center justify-between">
-          <Link to={`/users/${author.id}`} className="h-10 w-10">
-            <img
-              src={author.profilePicture}
-              alt={author.name}
-              className="h-full w-full rounded-full object-cover"
-            />
-          </Link>
+          {author && (
+            <Link to={`/users/${author.id}`} className="h-10 w-10">
+              <img
+                src={author.profilePicture}
+                alt={author.name}
+                className="h-full w-full rounded-full object-cover"
+              />
+            </Link>
+          )}
           <Link
             to={`/question/${id}`}
             className="flex items-center text-sm font-medium text-gray-800 hover:underline"

--- a/frontend/src/components/HighlightedQuestionsBox.tsx
+++ b/frontend/src/components/HighlightedQuestionsBox.tsx
@@ -1,36 +1,28 @@
 import { HighlightedQuestionCard } from "@/components/HighlightedQuestionCard";
+import { QuestionSummary } from "@/services/api/programmingForumSchemas";
 import React from "react";
 
-interface HighlightedQuestionCardProps {
-  id: number;
-  title: string;
-  content: string;
-  rating: number;
-  answerCount: number;
-  author: {
-    id: number;
-    name: string;
-    profilePicture: string;
-  };
-}
-
-export const HighlightedQuestionsBox: React.FC<{ questions: HighlightedQuestionCardProps[] }> = ({ questions }) => {
-    return (
-      <div className="p-6 rounded-lg shadow-md bg-gradient-to-t from-blue-50 via-blue-200 to-blue-300">
-        <h2 className="text-lg font-semibold text-gray-800 mb-4">Recommended for you:</h2>
-        <div className="grid grid-cols-3 gap-4">
-          {questions.map((question) => (
-            <HighlightedQuestionCard
-              key={question.id}
-              id={question.id}
-              title={question.title}
-              content={question.content}
-              votes={question.rating}
-              answerCount={question.answerCount}
-              author={question.author}
-            />
-          ))}
-        </div>
+export const HighlightedQuestionsBox: React.FC<{
+  questions: QuestionSummary[];
+}> = ({ questions }) => {
+  return (
+    <div className="rounded-lg bg-gradient-to-t from-blue-50 via-blue-200 to-blue-300 p-6 shadow-md">
+      <h2 className="mb-4 text-lg font-semibold text-gray-800">
+        Recommended for you:
+      </h2>
+      <div className="grid grid-cols-3 gap-4">
+        {questions.map((question) => (
+          <HighlightedQuestionCard
+            key={question.id}
+            id={question.id}
+            title={question.title}
+            questionBody={question.questionBody}
+            likeCount={question.likeCount}
+            commentCount={question.commentCount}
+            author={question.author}
+          />
+        ))}
       </div>
-    );
+    </div>
+  );
 };

--- a/frontend/src/components/QuestionCard.tsx
+++ b/frontend/src/components/QuestionCard.tsx
@@ -10,7 +10,7 @@ interface QuestionCardProps {
   content: string;
   votes: number;
   answerCount: number;
-  author: {
+  author?: {
     id: number;
     name: string;
     profilePicture: string;
@@ -45,13 +45,15 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({
           </div>
         </div>
         <div className="flex items-center justify-between">
-          <Link to={`/users/${author.id}`} className="h-10 w-10">
-            <img
-              src={author.profilePicture}
-              alt={author.name}
-              className="h-full w-full rounded-full object-cover"
-            />
-          </Link>
+          {author && (
+            <Link to={`/users/${author.id}`} className="h-10 w-10">
+              <img
+                src={author.profilePicture}
+                alt={author.name}
+                className="h-full w-full rounded-full object-cover"
+              />
+            </Link>
+          )}
           <Link
             to={`/question/${id}`}
             className="flex items-center text-sm font-medium text-gray-800 hover:underline"

--- a/frontend/src/components/TagCard.tsx
+++ b/frontend/src/components/TagCard.tsx
@@ -23,7 +23,7 @@ export const TagCard: React.FC<TagCardProps> = ({ tag }) => {
         <div className="flex flex-col gap-3 text-xs text-gray-700">
           <div className="flex items-center gap-1">
             <Users className="h-4 w-4" />
-            <span>{tag.followersCount} followers</span>
+            <span>{tag.followerCount} followers</span>
           </div>
           <div className="flex items-center gap-1">
             <Hash className="h-4 w-4" />
@@ -35,14 +35,14 @@ export const TagCard: React.FC<TagCardProps> = ({ tag }) => {
             <div className="h-10 w-10">
               <img
                 src={tag.photo}
-                alt={`The logo image of ${tag.name}`} 
+                alt={`The logo image of ${tag.name}`}
                 title={`alt:The logo image of ${tag.name}`}
                 className="rounded-full object-cover"
               />
             </div>
           )}
           <Link
-            to={`/tag/${tag.id}`}
+            to={`/tag/${tag.tagId}`}
             className="flex items-center text-sm font-medium text-gray-800 hover:underline"
           >
             View tag

--- a/frontend/src/routes/question.test.tsx
+++ b/frontend/src/routes/question.test.tsx
@@ -27,8 +27,8 @@ const mockQuestionData = vi.hoisted(
         reputationPoints: 100,
         profilePicture: "https://example.com/profile.jpg",
       },
-      rating: 10,
-      answerCount: 5,
+      likeCount: 10,
+      commentCount: 5,
       tags: [
         { id: "1", name: "javascript" },
         { id: "2", name: "react" },
@@ -47,7 +47,10 @@ vi.mock("@/services/api/programmingForumComponents", () => ({
   useVoteQuestion: vi.fn(() => ({
     mutateAsync: vi.fn(),
   })),
-  useRateQuestion: vi.fn(() => ({
+  useUpvoteQuestion: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+  })),
+  useDownvoteQuestion: vi.fn(() => ({
     mutateAsync: vi.fn(),
   })),
   useRateAnswer: vi.fn(() => ({
@@ -100,12 +103,12 @@ describe("QuestionPage", () => {
 
     // Check if rating is rendered
     expect(
-      screen.getByText(mockQuestionData.rating.toString()),
+      screen.getByText(mockQuestionData.likeCount.toString()),
     ).toBeInTheDocument();
 
     // Check if answer count is rendered
     expect(
-      screen.getByText(mockQuestionData.answerCount.toString()),
+      screen.getByText(mockQuestionData.commentCount.toString()),
     ).toBeInTheDocument();
 
     // Check if tags are rendered

--- a/frontend/src/routes/tag.test.tsx
+++ b/frontend/src/routes/tag.test.tsx
@@ -10,12 +10,12 @@ import TagPage from "./tag";
 const mockTagData = vi.hoisted(
   () =>
     ({
-      id: "1",
+      tagId: "1",
       name: "javascript",
       description:
         "A popular programming language primarily used for web development.",
       questionCount: 50,
-      followersCount: 1000,
+      followerCount: 1000,
       //createdAt: "2023-01-01T00:00:00Z",
     }) satisfies TagDetails,
 );
@@ -75,7 +75,7 @@ describe("TagPage", () => {
 
     // Check if followers count is rendered
     expect(
-      screen.getByText(`${mockTagData.followersCount}`, {
+      screen.getByText(`${mockTagData.followerCount}`, {
         exact: false,
       }),
     ).toBeInTheDocument();

--- a/frontend/src/routes/tag.tsx
+++ b/frontend/src/routes/tag.tsx
@@ -7,10 +7,7 @@ import { Link, useParams } from "react-router-dom";
 // import MeatDish from "@/assets/Icon/Food/MeatDish.svg?react";
 import ErrorAlert from "@/components/ErrorAlert";
 import { FullscreenLoading } from "@/components/FullscreenLoading";
-import {
-  useGetQuestionDetails,
-  useGetTagDetails,
-} from "@/services/api/programmingForumComponents";
+import { useGetTagDetails } from "@/services/api/programmingForumComponents";
 // import { Recipe } from "@/components/Recipe";
 import { HighlightedQuestionsBox } from "@/components/HighlightedQuestionsBox";
 import { QuestionCard } from "@/components/QuestionCard"; // Import your QuestionCard component
@@ -29,32 +26,8 @@ export default function TagPage() {
       enabled: !!tagId,
     },
   );
-  console.log(data?.data.highlightedQuestions);
-  const { data: questionsRecent } = useGetQuestionDetails(
-    {
-      pathParams: { questionId: 1 },
-    },
-    {
-      enabled: true,
-    },
-  );
 
-  const { data: questionsTop } = useGetQuestionDetails(
-    {
-      pathParams: { questionId: 1 },
-    },
-    {
-      enabled: true,
-    },
-  );
-  const tag = data?.data;
   const token = useAuthStore((s) => s.token);
-  //const { countries } = dish || {};
-
-  // const countryEmojis = useMemo(() => {
-  //   return (countries || "").split(", ").map(flag).join(" ");
-  // }, [countries]);
-  // const token = useAuthStore((s) => s.token);
 
   if (isLoading) {
     return <FullscreenLoading overlay />;
@@ -64,6 +37,7 @@ export default function TagPage() {
     return <ErrorAlert error={error} />;
   }
 
+  const tag = data?.data;
   if (!tag) {
     return (
       <ErrorAlert
@@ -74,6 +48,9 @@ export default function TagPage() {
       />
     );
   }
+
+  // TODO: fix this when backend catches up
+  const questions = tag?.relatedQuestions || [];
 
   return (
     <div className="container flex flex-col gap-4 self-stretch justify-self-stretch py-16">
@@ -91,7 +68,7 @@ export default function TagPage() {
       <div className="mb-4 flex items-center justify-between px-1">
         <span className="flex-1">{tag.description}</span>
         <div className="flex items-center gap-1">
-          <div className="font-bold">{tag.followersCount}</div>
+          <div className="font-bold">{tag.followerCount}</div>
           <div className="text-sm text-gray-500">Followers</div>
         </div>
       </div>
@@ -117,37 +94,35 @@ export default function TagPage() {
             <TabsTrigger value="recent">Recent</TabsTrigger>
           </TabsList>
           <TabsContent value="top-rated" className="flex flex-col gap-4">
-            <HighlightedQuestionsBox
-              questions={data?.data?.highlightedQuestions || []}
-            />
+            <HighlightedQuestionsBox questions={questions || []} />
             <div className="grid grid-cols-3 gap-4">
-              {questionsTop?.data && (
-                <QuestionCard
-                  id={questionsTop.data.id}
-                  title={questionsTop.data.title}
-                  content={questionsTop.data.content}
-                  votes={questionsTop.data.rating}
-                  answerCount={questionsTop.data.answerCount}
-                  author={questionsTop.data.author}
-                />
-              )}
+              {questions &&
+                questions.map((question) => (
+                  <QuestionCard
+                    id={question.id}
+                    title={question.title}
+                    content={question.questionBody!}
+                    votes={question.likeCount}
+                    answerCount={question.commentCount}
+                    author={question.author}
+                  />
+                ))}
             </div>
           </TabsContent>
           <TabsContent value="recent" className="flex flex-col gap-4">
-            <HighlightedQuestionsBox
-              questions={data?.data?.highlightedQuestions || []}
-            />
+            <HighlightedQuestionsBox questions={questions || []} />
             <div className="grid grid-cols-3 gap-4">
-              {questionsRecent?.data && (
-                <QuestionCard
-                  id={questionsRecent.data.id}
-                  title={questionsRecent.data.title}
-                  content={questionsRecent.data.content}
-                  votes={questionsRecent.data.rating}
-                  answerCount={questionsRecent.data.answerCount}
-                  author={questionsRecent?.data?.author}
-                />
-              )}
+              {questions &&
+                questions.map((question) => (
+                  <QuestionCard
+                    id={question.id}
+                    title={question.title}
+                    content={question.questionBody!}
+                    votes={question.likeCount}
+                    answerCount={question.commentCount}
+                    author={question.author}
+                  />
+                ))}
             </div>
           </TabsContent>
         </Tabs>

--- a/frontend/src/services/api/programmingForumComponents.ts
+++ b/frontend/src/services/api/programmingForumComponents.ts
@@ -916,11 +916,11 @@ export const useDeleteQuestion = (
   });
 };
 
-export type RateQuestionPathParams = {
+export type UpvoteQuestionPathParams = {
   questionId: number;
 };
 
-export type RateQuestionError = Fetcher.ErrorWrapper<
+export type UpvoteQuestionError = Fetcher.ErrorWrapper<
   | {
       status: 400;
       payload: Responses.BadRequestResponse;
@@ -935,43 +935,34 @@ export type RateQuestionError = Fetcher.ErrorWrapper<
     }
 >;
 
-export type RateQuestionRequestBody = {
-  /**
-   * @minimum -1
-   * @maximum 1
-   */
-  rating: number;
-};
-
-export type RateQuestionVariables = {
-  body: RateQuestionRequestBody;
-  pathParams: RateQuestionPathParams;
+export type UpvoteQuestionVariables = {
+  pathParams: UpvoteQuestionPathParams;
 } & ProgrammingForumContext["fetcherOptions"];
 
-export const fetchRateQuestion = (
-  variables: RateQuestionVariables,
+export const fetchUpvoteQuestion = (
+  variables: UpvoteQuestionVariables,
   signal?: AbortSignal,
 ) =>
   programmingForumFetch<
     undefined,
-    RateQuestionError,
-    RateQuestionRequestBody,
+    UpvoteQuestionError,
+    undefined,
     {},
     {},
-    RateQuestionPathParams
+    UpvoteQuestionPathParams
   >({
-    url: "/questions/{questionId}/rate",
+    url: "/questions/{questionId}/upvote",
     method: "post",
     ...variables,
     signal,
   });
 
-export const useRateQuestion = (
+export const useUpvoteQuestion = (
   options?: Omit<
     reactQuery.UseMutationOptions<
       undefined,
-      RateQuestionError,
-      RateQuestionVariables
+      UpvoteQuestionError,
+      UpvoteQuestionVariables
     >,
     "mutationFn"
   >,
@@ -979,11 +970,74 @@ export const useRateQuestion = (
   const { fetcherOptions } = useProgrammingForumContext();
   return reactQuery.useMutation<
     undefined,
-    RateQuestionError,
-    RateQuestionVariables
+    UpvoteQuestionError,
+    UpvoteQuestionVariables
   >({
-    mutationFn: (variables: RateQuestionVariables) =>
-      fetchRateQuestion({ ...fetcherOptions, ...variables }),
+    mutationFn: (variables: UpvoteQuestionVariables) =>
+      fetchUpvoteQuestion({ ...fetcherOptions, ...variables }),
+    ...options,
+  });
+};
+
+export type DownvoteQuestionPathParams = {
+  questionId: number;
+};
+
+export type DownvoteQuestionError = Fetcher.ErrorWrapper<
+  | {
+      status: 400;
+      payload: Responses.BadRequestResponse;
+    }
+  | {
+      status: 401;
+      payload: Responses.UnauthorizedResponse;
+    }
+  | {
+      status: 404;
+      payload: Responses.NotFoundResponse;
+    }
+>;
+
+export type DownvoteQuestionVariables = {
+  pathParams: DownvoteQuestionPathParams;
+} & ProgrammingForumContext["fetcherOptions"];
+
+export const fetchDownvoteQuestion = (
+  variables: DownvoteQuestionVariables,
+  signal?: AbortSignal,
+) =>
+  programmingForumFetch<
+    undefined,
+    DownvoteQuestionError,
+    undefined,
+    {},
+    {},
+    DownvoteQuestionPathParams
+  >({
+    url: "/questions/{questionId}/downvote",
+    method: "post",
+    ...variables,
+    signal,
+  });
+
+export const useDownvoteQuestion = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      DownvoteQuestionError,
+      DownvoteQuestionVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProgrammingForumContext();
+  return reactQuery.useMutation<
+    undefined,
+    DownvoteQuestionError,
+    DownvoteQuestionVariables
+  >({
+    mutationFn: (variables: DownvoteQuestionVariables) =>
+      fetchDownvoteQuestion({ ...fetcherOptions, ...variables }),
     ...options,
   });
 };

--- a/frontend/src/services/api/programmingForumFetcher.ts
+++ b/frontend/src/services/api/programmingForumFetcher.ts
@@ -10,7 +10,7 @@ import {
 
 const baseUrl = "/api/v1";
 
-const USE_TEMPORARY_MOCKS = true;
+const USE_TEMPORARY_MOCKS = false;
 
 export type ErrorWrapper<TError> =
   | TError

--- a/frontend/src/services/api/programmingForumSchemas.ts
+++ b/frontend/src/services/api/programmingForumSchemas.ts
@@ -97,7 +97,7 @@ export type UpdateQuestion = {
 };
 
 /**
- * @example {"id":1,"title":"What is the best way to learn programming?","content":"I want to learn programming, but I don't know where to start. What is the best way to learn programming?","author":{"$ref":"#/components/schemas/UserSummary/examples/0"},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","tags":[{"$ref":"#/components/schemas/TagSummary/examples/0"}],"rating":10,"answerCount":2,"viewCount":100,"bookmarked":false,"selfRating":0}
+ * @example {"id":1,"title":"What is the best way to learn programming?","content":"I want to learn programming, but I don't know where to start. What is the best way to learn programming?","author":{"$ref":"#/components/schemas/UserSummary/examples/0"},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","tags":[{"$ref":"#/components/schemas/TagSummary/examples/0"}],"likeCount":10,"commentCount":2,"viewCount":100,"bookmarked":false,"selfRating":0}
  */
 export type QuestionDetails = {
   id: number;
@@ -113,8 +113,8 @@ export type QuestionDetails = {
    */
   updatedAt: string;
   tags: TagSummary[];
-  rating: number;
-  answerCount: number;
+  likeCount: number;
+  commentCount: number;
   viewCount?: number;
   bookmarked?: boolean;
   /**
@@ -130,16 +130,16 @@ export type QuestionDetails = {
 export type QuestionSummary = {
   id: number;
   title: string;
-  content?: string;
-  author: UserSummary;
+  questionBody?: string;
+  author?: UserSummary;
   /**
    * @format date-time
    */
   createdAt: string;
   difficultyLevel: DifficultyLevel;
   tags: TagSummary[];
-  rating: number;
-  answerCount: number;
+  likeCount: number;
+  commentCount: number;
   viewCount?: number;
   /**
    * @minimum -1
@@ -181,13 +181,13 @@ export type AnswerDetails = {
 };
 
 /**
- * @example {"id":"python","name":"Python","description":"Python is a programming language.","questionCount":100,"followersCount":1000,"following":false,"photo":"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/220px-Python-logo-notext.svg.png","authors":["Guido van Rossum"],"inceptionYear":"1991","fileExtension":".py","officialWebsite":"https://www.python.org","stackExchangeTag":"python"}
- * @example {"id":"java","name":"Java","type":"PROGRAMMING_LANGUAGE","description":"Java is a class-based, object-oriented programming language.","questionCount":200,"followersCount":800,"following":true,"photo":"https://upload.wikimedia.org/wikipedia/en/thumb/3/30/Java_programming_language_logo.svg/182px-Java_programming_language_logo.svg.png","authors":["James Gosling"],"inceptionYear":"1995","fileExtension":".java","officialWebsite":"https://www.java.com","stackExchangeTag":"java"}
- * @example {"id":"react","name":"React","type":"SOFTWARE_LIBRARY","description":"React is a JavaScript library for building user interfaces.","questionCount":150,"followersCount":600,"following":false,"photo":"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/180px-React-icon.svg.png","officialWebsite":"https://reactjs.org","stackExchangeTag":"reactjs"}
- * @example {"id":"oop","name":"Object-Oriented Programming","type":"PROGRAMMING_PARADIGM","description":"OOP is a programming paradigm based on objects containing data and code.","questionCount":80,"followersCount":400,"following":true,"photo":"https://example.com/oop-icon.png","stackExchangeTag":"oop"}
+ * @example {"tagId":"python","name":"Python","description":"Python is a programming language.","questionCount":100,"followersCount":1000,"following":false,"photo":"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/220px-Python-logo-notext.svg.png","authors":["Guido van Rossum"],"inceptionYear":"1991","fileExtension":".py","officialWebsite":"https://www.python.org","stackExchangeTag":"python"}
+ * @example {"tagId":"java","name":"Java","type":"PROGRAMMING_LANGUAGE","description":"Java is a class-based, object-oriented programming language.","questionCount":200,"followersCount":800,"following":true,"photo":"https://upload.wikimedia.org/wikipedia/en/thumb/3/30/Java_programming_language_logo.svg/182px-Java_programming_language_logo.svg.png","authors":["James Gosling"],"inceptionYear":"1995","fileExtension":".java","officialWebsite":"https://www.java.com","stackExchangeTag":"java"}
+ * @example {"tagId":"react","name":"React","type":"SOFTWARE_LIBRARY","description":"React is a JavaScript library for building user interfaces.","questionCount":150,"followersCount":600,"following":false,"photo":"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/180px-React-icon.svg.png","officialWebsite":"https://reactjs.org","stackExchangeTag":"reactjs"}
+ * @example {"tagId":"oop","name":"Object-Oriented Programming","type":"PROGRAMMING_PARADIGM","description":"OOP is a programming paradigm based on objects containing data and code.","questionCount":80,"followersCount":400,"following":true,"photo":"https://example.com/oop-icon.png","stackExchangeTag":"oop"}
  */
 export type TagDetails = {
-  id: string;
+  tagId: string;
   name: string;
   tagType?: TagType;
   description: string;
@@ -227,6 +227,7 @@ export type TagDetails = {
    * Available for Programming Language, Programming Paradigm and Computer Science Term tags
    */
   stackExchangeTag?: string;
+  relatedQuestions?: QuestionSummary[];
 };
 
 /**

--- a/mobile/app/tags/[tagId].tsx
+++ b/mobile/app/tags/[tagId].tsx
@@ -13,12 +13,9 @@ import {
   View,
   VStack,
 } from "@/components/ui";
-import {
-  useGetQuestionDetails,
-  useGetTagDetails,
-} from "@/services/api/programmingForumComponents";
+import { useGetTagDetails } from "@/services/api/programmingForumComponents";
 import useAuthStore from "@/services/auth";
-import { Link, useLocalSearchParams } from "expo-router";
+import { Href, Link, useLocalSearchParams } from "expo-router";
 import { Plus } from "lucide-react-native";
 import { useState } from "react";
 
@@ -34,35 +31,13 @@ export default function TagPage() {
     }
   );
 
-  const { data: questionsRecent, isLoading: isLoadingRecent } =
-    useGetQuestionDetails(
-      {
-        pathParams: { questionId: 1 }, // TODO fix later
-        queryParams: { sort: "recent", limit: 10 },
-      },
-      {
-        enabled: !!tagId,
-      }
-    );
-
-  const { data: questionsTop, isLoading: isLoadingTop } = useGetQuestionDetails(
-    {
-      pathParams: { questionId: 1 }, // TODO fix later
-      queryParams: { sort: "top", limit: 10 },
-    },
-    {
-      enabled: !!tagId,
-    }
-  );
-
   const tag = data?.data;
   const token = useAuthStore((s) => s.token);
   const [tab, setTab] = useState<"top-rated" | "recent">("top-rated");
 
-  const highlightedQuestions = data?.data.highlightedQuestions;
-  const [scrollQuestions, setScrollQuestions] = useState(1);
+  const highlightedQuestions = tag?.relatedQuestions;
 
-  if (isLoading || isLoadingRecent || isLoadingTop) {
+  if (isLoading) {
     return <FullscreenLoading overlay />;
   }
 
@@ -80,6 +55,9 @@ export default function TagPage() {
       />
     );
   }
+
+  // TODO: fix this when backend catches up
+  const questions = tag?.relatedQuestions || [];
 
   return (
     <ScrollView contentContainerStyle={{ flexGrow: 1, paddingVertical: 16 }}>
@@ -105,9 +83,9 @@ export default function TagPage() {
           <HStack style={{ alignItems: "center", gap: 16 }}>
             <Text style={{ fontSize: 20, fontWeight: "600" }}>Questions</Text>
             {!!token && (
-              <Link href={`/question/new?tagId=${tag.id}`} asChild>
+              <Link href={`/question/new?tagId=${tag.tagId}` as Href} asChild>
                 <Button
-                  size="icon"
+                  size="md"
                   style={{ borderRadius: 9999, backgroundColor: "#ef4444" }}
                 >
                   <Icon as={Plus} color="white" />
@@ -130,46 +108,45 @@ export default function TagPage() {
             </Button>
           </ButtonGroup>
 
-          {highlightedQuestions?.map((question, index) => (
-            (index < scrollQuestions*10) && // TODO: don't show all cards initially, reload after user asks
-              <QuestionCard
-                key={question.id}
-                id={question.id}
-                title={question.title}
-                content={question.content}
-                votes={question.rating}
-                answerCount={question.answerCount}
-                author={question.author}
-                highlighted={true}
-              />
-          ))} 
+          {highlightedQuestions?.map((question) => (
+            <QuestionCard
+              key={question.id}
+              id={String(question.id)}
+              title={question.title}
+              content={question.questionBody}
+              votes={question.likeCount}
+              answerCount={question.commentCount}
+              author={question.author}
+              highlighted={true}
+            />
+          ))}
 
           {tab === "top-rated" ? (
             <View style={{ gap: 16 }}>
-              {questionsTop?.data &&
-                [questionsTop?.data].map((question) => (
+              {questions &&
+                questions.map((question) => (
                   <QuestionCard
                     key={question.id}
-                    id={question.id}
+                    id={String(question.id)}
                     title={question.title}
-                    content={question.content}
-                    votes={question.rating}
-                    answerCount={question.answerCount}
+                    content={question.questionBody}
+                    votes={question.likeCount}
+                    answerCount={question.commentCount}
                     author={question.author}
                   />
                 ))}
             </View>
           ) : (
             <View style={{ gap: 16 }}>
-              {questionsRecent?.data &&
-                [questionsRecent?.data].map((question) => (
+              {questions &&
+                questions.map((question) => (
                   <QuestionCard
                     key={question.id}
-                    id={question.id}
+                    id={String(question.id)}
                     title={question.title}
-                    content={question.content}
-                    votes={question.rating}
-                    answerCount={question.answerCount}
+                    content={question.questionBody}
+                    votes={question.likeCount}
+                    answerCount={question.commentCount}
                     author={question.author}
                   />
                 ))}

--- a/mobile/components/QuestionCard.tsx
+++ b/mobile/components/QuestionCard.tsx
@@ -1,5 +1,5 @@
-import { Card } from "@/components/ui/card";
 import { Image, Text } from "@/components/ui";
+import { Card } from "@/components/ui/card";
 import { Link } from "expo-router";
 import { ArrowRight, MessageSquare, Star } from "lucide-react-native";
 import React from "react";
@@ -8,11 +8,11 @@ import { View } from "react-native";
 interface QuestionCardProps {
   id: string;
   title: string;
-  content: string;
+  content?: string;
   votes: number;
   answerCount: number;
-  author: {
-    id: string;
+  author?: {
+    id: number;
     name: string;
     profilePicture: string;
   };
@@ -36,9 +36,11 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({
     >
       <View className="flex flex-col gap-6">
         {highlighted && (
-          <Text className="text-xs font-semibold text-blue-700">Beginner Friendly</Text>
+          <Text className="text-xs font-semibold text-blue-700">
+            Beginner Friendly
+          </Text>
         )}
-        
+
         <Text
           className={`line-clamp-2 text-xl font-semibold ${
             highlighted ? "text-blue-800" : "text-gray-800"
@@ -59,18 +61,22 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({
             <Text>{votes} votes</Text>
           </View>
           <View className="flex items-center gap-1">
-            <MessageSquare className={`h-4 w-4 ${highlighted ? "text-blue-600" : ""}`} />
+            <MessageSquare
+              className={`h-4 w-4 ${highlighted ? "text-blue-600" : ""}`}
+            />
             <Text>{answerCount} answers</Text>
           </View>
         </View>
         <View className="flex items-center justify-between">
-          <Link href={`/users/${author.id}`} className="h-10 w-10">
-            <Image
-              source={{ uri: author.profilePicture }}
-              alt={author.name}
-              className="h-full w-full rounded-full object-cover"
-            />
-          </Link>
+          {author && (
+            <Link href={`/users/${author.id}`} className="h-10 w-10">
+              <Image
+                source={{ uri: author.profilePicture }}
+                alt={author.name}
+                className="h-full w-full rounded-full object-cover"
+              />
+            </Link>
+          )}
           <Link
             href={`/question/${id}`}
             className={`flex items-center text-sm font-medium ${

--- a/mobile/services/api/programmingForumComponents.ts
+++ b/mobile/services/api/programmingForumComponents.ts
@@ -916,11 +916,11 @@ export const useDeleteQuestion = (
   });
 };
 
-export type RateQuestionPathParams = {
+export type UpvoteQuestionPathParams = {
   questionId: number;
 };
 
-export type RateQuestionError = Fetcher.ErrorWrapper<
+export type UpvoteQuestionError = Fetcher.ErrorWrapper<
   | {
       status: 400;
       payload: Responses.BadRequestResponse;
@@ -935,43 +935,34 @@ export type RateQuestionError = Fetcher.ErrorWrapper<
     }
 >;
 
-export type RateQuestionRequestBody = {
-  /**
-   * @minimum -1
-   * @maximum 1
-   */
-  rating: number;
-};
-
-export type RateQuestionVariables = {
-  body: RateQuestionRequestBody;
-  pathParams: RateQuestionPathParams;
+export type UpvoteQuestionVariables = {
+  pathParams: UpvoteQuestionPathParams;
 } & ProgrammingForumContext["fetcherOptions"];
 
-export const fetchRateQuestion = (
-  variables: RateQuestionVariables,
+export const fetchUpvoteQuestion = (
+  variables: UpvoteQuestionVariables,
   signal?: AbortSignal,
 ) =>
   programmingForumFetch<
     undefined,
-    RateQuestionError,
-    RateQuestionRequestBody,
+    UpvoteQuestionError,
+    undefined,
     {},
     {},
-    RateQuestionPathParams
+    UpvoteQuestionPathParams
   >({
-    url: "/questions/{questionId}/rate",
+    url: "/questions/{questionId}/upvote",
     method: "post",
     ...variables,
     signal,
   });
 
-export const useRateQuestion = (
+export const useUpvoteQuestion = (
   options?: Omit<
     reactQuery.UseMutationOptions<
       undefined,
-      RateQuestionError,
-      RateQuestionVariables
+      UpvoteQuestionError,
+      UpvoteQuestionVariables
     >,
     "mutationFn"
   >,
@@ -979,11 +970,74 @@ export const useRateQuestion = (
   const { fetcherOptions } = useProgrammingForumContext();
   return reactQuery.useMutation<
     undefined,
-    RateQuestionError,
-    RateQuestionVariables
+    UpvoteQuestionError,
+    UpvoteQuestionVariables
   >({
-    mutationFn: (variables: RateQuestionVariables) =>
-      fetchRateQuestion({ ...fetcherOptions, ...variables }),
+    mutationFn: (variables: UpvoteQuestionVariables) =>
+      fetchUpvoteQuestion({ ...fetcherOptions, ...variables }),
+    ...options,
+  });
+};
+
+export type DownvoteQuestionPathParams = {
+  questionId: number;
+};
+
+export type DownvoteQuestionError = Fetcher.ErrorWrapper<
+  | {
+      status: 400;
+      payload: Responses.BadRequestResponse;
+    }
+  | {
+      status: 401;
+      payload: Responses.UnauthorizedResponse;
+    }
+  | {
+      status: 404;
+      payload: Responses.NotFoundResponse;
+    }
+>;
+
+export type DownvoteQuestionVariables = {
+  pathParams: DownvoteQuestionPathParams;
+} & ProgrammingForumContext["fetcherOptions"];
+
+export const fetchDownvoteQuestion = (
+  variables: DownvoteQuestionVariables,
+  signal?: AbortSignal,
+) =>
+  programmingForumFetch<
+    undefined,
+    DownvoteQuestionError,
+    undefined,
+    {},
+    {},
+    DownvoteQuestionPathParams
+  >({
+    url: "/questions/{questionId}/downvote",
+    method: "post",
+    ...variables,
+    signal,
+  });
+
+export const useDownvoteQuestion = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      DownvoteQuestionError,
+      DownvoteQuestionVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProgrammingForumContext();
+  return reactQuery.useMutation<
+    undefined,
+    DownvoteQuestionError,
+    DownvoteQuestionVariables
+  >({
+    mutationFn: (variables: DownvoteQuestionVariables) =>
+      fetchDownvoteQuestion({ ...fetcherOptions, ...variables }),
     ...options,
   });
 };
@@ -1457,6 +1511,67 @@ export const useRateAnswer = (
   });
 };
 
+export type CreateTagError = Fetcher.ErrorWrapper<
+  | {
+      status: 400;
+      payload: Responses.BadRequestResponse;
+    }
+  | {
+      status: 401;
+      payload: Responses.UnauthorizedResponse;
+    }
+>;
+
+export type CreateTagResponse = {
+  /**
+   * Internal status code of the response. An HTTP 200 response with an internal 500 status code is an error response. Prioritize the inner status over the HTTP status.
+   *
+   * @example 200
+   * @example 201
+   */
+  status: 200 | 201;
+  data: Schemas.TagDetails;
+};
+
+export type CreateTagVariables = {
+  body: Schemas.NewTag;
+} & ProgrammingForumContext["fetcherOptions"];
+
+export const fetchCreateTag = (
+  variables: CreateTagVariables,
+  signal?: AbortSignal,
+) =>
+  programmingForumFetch<
+    CreateTagResponse,
+    CreateTagError,
+    Schemas.NewTag,
+    {},
+    {},
+    {}
+  >({ url: "/tags", method: "post", ...variables, signal });
+
+export const useCreateTag = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      CreateTagResponse,
+      CreateTagError,
+      CreateTagVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProgrammingForumContext();
+  return reactQuery.useMutation<
+    CreateTagResponse,
+    CreateTagError,
+    CreateTagVariables
+  >({
+    mutationFn: (variables: CreateTagVariables) =>
+      fetchCreateTag({ ...fetcherOptions, ...variables }),
+    ...options,
+  });
+};
+
 export type GetTagDetailsPathParams = {
   tagId: string;
 };
@@ -1633,6 +1748,10 @@ export type SearchQuestionsQueryParams = {
    * Comma-separated list of tag IDs
    */
   tags?: string;
+  /**
+   * Filter by difficulty level
+   */
+  difficulty?: Schemas.DifficultyLevel;
   /**
    * Page number
    *

--- a/mobile/services/api/programmingForumSchemas.ts
+++ b/mobile/services/api/programmingForumSchemas.ts
@@ -5,6 +5,18 @@
  */
 export type ExperienceLevel = "BEGINNER" | "INTERMEDIATE" | "ADVANCED";
 
+export type NewTag = {
+  name: string;
+  description: string;
+};
+
+export type TagType =
+  | "PROGRAMMING_LANGUAGE"
+  | "PROGRAMMING_PARADIGM"
+  | "COMPUTER_SCIENCE_TERM"
+  | "SOFTWARE_LIBRARY"
+  | "USER_DEFINED";
+
 export type UserRegistration = {
   username: string;
   /**
@@ -69,10 +81,13 @@ export type UserSummary = {
   name: string;
 };
 
+export type DifficultyLevel = "EASY" | "MEDIUM" | "HARD";
+
 export type NewQuestion = {
   title: string;
   content: string;
-  tags: string[];
+  tagIds?: number[];
+  difficultyLevel: DifficultyLevel;
 };
 
 export type UpdateQuestion = {
@@ -82,7 +97,7 @@ export type UpdateQuestion = {
 };
 
 /**
- * @example {"id":1,"title":"What is the best way to learn programming?","content":"I want to learn programming, but I don't know where to start. What is the best way to learn programming?","author":{"$ref":"#/components/schemas/UserSummary/examples/0"},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","tags":[{"$ref":"#/components/schemas/TagSummary/examples/0"}],"rating":10,"answerCount":2,"viewCount":100,"bookmarked":false,"selfRating":0}
+ * @example {"id":1,"title":"What is the best way to learn programming?","content":"I want to learn programming, but I don't know where to start. What is the best way to learn programming?","author":{"$ref":"#/components/schemas/UserSummary/examples/0"},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","tags":[{"$ref":"#/components/schemas/TagSummary/examples/0"}],"likeCount":10,"commentCount":2,"viewCount":100,"bookmarked":false,"selfRating":0}
  */
 export type QuestionDetails = {
   id: number;
@@ -98,8 +113,8 @@ export type QuestionDetails = {
    */
   updatedAt: string;
   tags: TagSummary[];
-  rating: number;
-  answerCount: number;
+  likeCount: number;
+  commentCount: number;
   viewCount?: number;
   bookmarked?: boolean;
   /**
@@ -115,15 +130,16 @@ export type QuestionDetails = {
 export type QuestionSummary = {
   id: number;
   title: string;
-  content: string;
-  author: UserSummary;
+  questionBody?: string;
+  author?: UserSummary;
   /**
    * @format date-time
    */
   createdAt: string;
+  difficultyLevel: DifficultyLevel;
   tags: TagSummary[];
-  rating: number;
-  answerCount: number;
+  likeCount: number;
+  commentCount: number;
   viewCount?: number;
   /**
    * @minimum -1
@@ -165,20 +181,53 @@ export type AnswerDetails = {
 };
 
 /**
- * @example {"id":"python","name":"Python","description":"Python is a programming language.","questionCount":100,"followersCount":1000,"following":false,"photo":"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/220px-Python-logo-notext.svg.png"}
+ * @example {"tagId":"python","name":"Python","description":"Python is a programming language.","questionCount":100,"followersCount":1000,"following":false,"photo":"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/220px-Python-logo-notext.svg.png","authors":["Guido van Rossum"],"inceptionYear":"1991","fileExtension":".py","officialWebsite":"https://www.python.org","stackExchangeTag":"python"}
+ * @example {"tagId":"java","name":"Java","type":"PROGRAMMING_LANGUAGE","description":"Java is a class-based, object-oriented programming language.","questionCount":200,"followersCount":800,"following":true,"photo":"https://upload.wikimedia.org/wikipedia/en/thumb/3/30/Java_programming_language_logo.svg/182px-Java_programming_language_logo.svg.png","authors":["James Gosling"],"inceptionYear":"1995","fileExtension":".java","officialWebsite":"https://www.java.com","stackExchangeTag":"java"}
+ * @example {"tagId":"react","name":"React","type":"SOFTWARE_LIBRARY","description":"React is a JavaScript library for building user interfaces.","questionCount":150,"followersCount":600,"following":false,"photo":"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/180px-React-icon.svg.png","officialWebsite":"https://reactjs.org","stackExchangeTag":"reactjs"}
+ * @example {"tagId":"oop","name":"Object-Oriented Programming","type":"PROGRAMMING_PARADIGM","description":"OOP is a programming paradigm based on objects containing data and code.","questionCount":80,"followersCount":400,"following":true,"photo":"https://example.com/oop-icon.png","stackExchangeTag":"oop"}
  */
 export type TagDetails = {
-  id?: string;
-  name?: string;
-  description?: string;
+  tagId: string;
+  name: string;
+  tagType?: TagType;
+  description: string;
   questionCount?: number;
-  followersCount?: number;
+  followerCount?: number;
   following?: boolean;
   /**
    * @format url
    */
   photo?: string;
   highlightedQuestions?: QuestionSummary[];
+  /**
+   * For Programming Language tags
+   *
+   * @format url
+   */
+  logoImage?: string;
+  /**
+   * For Programming Language tags
+   */
+  author?: string;
+  /**
+   * For Programming Language tags
+   */
+  inceptionYear?: string;
+  /**
+   * For Programming Language tags
+   */
+  fileExtension?: string;
+  /**
+   * For Programming Language tags
+   *
+   * @format url
+   */
+  officialWebsite?: string;
+  /**
+   * Available for Programming Language, Programming Paradigm and Computer Science Term tags
+   */
+  stackExchangeTag?: string;
+  relatedQuestions?: QuestionSummary[];
 };
 
 /**

--- a/swagger/openapi.yml
+++ b/swagger/openapi.yml
@@ -459,12 +459,12 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundResponse"
 
-  /questions/{questionId}/rate:
+  /questions/{questionId}/upvote:
     post:
       tags:
         - questions
-      summary: Rate a question
-      operationId: rateQuestion
+      summary: Upvote a question
+      operationId: upvoteQuestion
       security:
         - bearerAuth: []
       parameters:
@@ -473,22 +473,33 @@ paths:
           required: true
           schema:
             type: integer
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - rating
-              properties:
-                rating:
-                  type: integer
-                  minimum: -1
-                  maximum: 1
       responses:
         "200":
           description: Question successfully rated
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+
+  /questions/{questionId}/downvote:
+    post:
+      tags:
+        - questions
+      summary: Downvote a question
+      operationId: downvoteQuestion
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: questionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Question successfully downvoted
         "400":
           $ref: "#/components/responses/BadRequestResponse"
         "401":
@@ -1283,8 +1294,8 @@ components:
         - createdAt
         - updatedAt
         - tags
-        - rating
-        - answerCount
+        - likeCount
+        - commentCount
       properties:
         id:
           type: integer
@@ -1304,9 +1315,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TagSummary"
-        rating:
+        likeCount:
           type: integer
-        answerCount:
+        commentCount:
           type: integer
         viewCount:
           type: integer
@@ -1327,8 +1338,8 @@ components:
           updatedAt: "2024-01-01T00:00:00Z"
           tags:
             - $ref: "#/components/schemas/TagSummary/examples/0"
-          rating: 10
-          answerCount: 2
+          likeCount: 10
+          commentCount: 2
           viewCount: 100
           bookmarked: false
           selfRating: 0
@@ -1338,18 +1349,17 @@ components:
       required:
         - id
         - title
-        - author
+        - likeCount
         - difficultyLevel
         - createdAt
-        - answerCount
-        - rating
+        - commentCount
         - tags
       properties:
         id:
           type: integer
         title:
           type: string
-        content:
+        questionBody:
           type: string
         author:
           $ref: "#/components/schemas/UserSummary"
@@ -1362,9 +1372,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TagSummary"
-        rating:
+        likeCount:
           type: integer
-        answerCount:
+        commentCount:
           type: integer
         viewCount:
           type: integer
@@ -1460,12 +1470,12 @@ components:
     TagDetails:
       type: object
       required:
-        - id
+        - tagId
         - name
         - type
         - description
       properties:
-        id:
+        tagId:
           type: string
         name:
           type: string
@@ -1507,8 +1517,12 @@ components:
         stackExchangeTag:
           type: string
           description: Available for Programming Language, Programming Paradigm and Computer Science Term tags
+        relatedQuestions:
+          type: array
+          items:
+            $ref: "#/components/schemas/QuestionSummary"
       examples:
-        - id: "python"
+        - tagId: "python"
           name: "Python"
           description: "Python is a programming language."
           questionCount: 100
@@ -1521,7 +1535,7 @@ components:
           fileExtension: ".py"
           officialWebsite: "https://www.python.org"
           stackExchangeTag: "python"
-        - id: "java"
+        - tagId: "java"
           name: "Java"
           type: "PROGRAMMING_LANGUAGE"
           description: "Java is a class-based, object-oriented programming language."
@@ -1535,7 +1549,7 @@ components:
           fileExtension: ".java"
           officialWebsite: "https://www.java.com"
           stackExchangeTag: "java"
-        - id: "react"
+        - tagId: "react"
           name: "React"
           type: "SOFTWARE_LIBRARY"
           description: "React is a JavaScript library for building user interfaces."
@@ -1545,7 +1559,7 @@ components:
           photo: "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/180px-React-icon.svg.png"
           officialWebsite: "https://reactjs.org"
           stackExchangeTag: "reactjs"
-        - id: "oop"
+        - tagId: "oop"
           name: "Object-Oriented Programming"
           type: "PROGRAMMING_PARADIGM"
           description: "OOP is a programming paradigm based on objects containing data and code."


### PR DESCRIPTION
## 📋 Proposed Changes
- Replaced rating/answerCount fields with likeCount/commentCount throughout frontend and mobile
- Updated schema definitions and API endpoints to match new backend contract
- Refactored vote system to use separate upvote/downvote endpoints
- Fixed tag details to use tagId instead of id
- Updated JWT token expiration to 24 hours
- Fixed question card to handle optional author fields

## Related Issue
Closes #511

## Additional Notes
This PR primarily focuses on aligning the frontend/mobile interfaces with the updated backend API contract. The main changes involve:

1. Field renaming:
   - rating -> likeCount
   - answerCount -> commentCount
   - id -> tagId (for tags)

2. API changes:
   - Split rating endpoint into separate upvote/downvote endpoints (schema)
   - Updated JWT expiration time for better user experience (backend)

3. UI improvements:
   - Made author field optional in question cards
   - Updated all components to use new field names
   - Fixed mobile navigation
