### PR TITLE
[FE] Implement Tag Create

### DIFF
--- a/frontend/src/components/CreateTagForm.test.tsx
+++ b/frontend/src/components/CreateTagForm.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CreateTagForm } from "./CreateTagForm"; // Import your component
+import { useCreateTag } from "@/services/api/programmingForumComponents"; // Import the hook
+
+// Mock the useCreateTag hook
+vi.mock("@/services/api/programmingForumComponents", () => ({
+  useCreateTag: vi.fn(),
+}));
+
+describe("CreateTagForm", () => {
+  const mockCreateTag = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCreateTag).mockReturnValue({
+      mutateAsync: mockCreateTag,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateTag>);
+  });
+
+  it("renders form elements correctly", () => {
+    render(<CreateTagForm />);
+
+    // Check for presence of form fields
+    expect(screen.getByPlaceholderText("Tag name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Tag description")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create Tag" }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits form with valid data when 'Create Tag' is clicked", async () => {
+    render(<CreateTagForm />);
+
+    const nameInput = screen.getByPlaceholderText("Tag name");
+    const descriptionInput = screen.getByPlaceholderText("Tag description");
+    const submitButton = screen.getByRole("button", { name: "Create Tag" });
+
+    // Simulate user input
+    fireEvent.change(nameInput, { target: { value: "NewTag" } });
+    fireEvent.change(descriptionInput, {
+      target: { value: "A description for NewTag" },
+    });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      // Check if the createTag function was called with the correct arguments
+      expect(mockCreateTag).toHaveBeenCalledWith({
+        body: {
+          name: "NewTag",
+          description: "A description for NewTag",
+        },
+      });
+    });
+  });
+
+  it("disables submit button when form is empty", () => {
+    render(<CreateTagForm />);
+
+    const submitButton = screen.getByRole("button", { name: "Create Tag" });
+
+    // Initially, the submit button should be disabled
+    expect(submitButton).toBeDisabled();
+
+    // Simulate filling the form
+    fireEvent.change(screen.getByPlaceholderText("Tag name"), {
+      target: { value: "NewTag" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Tag description"), {
+      target: { value: "Description" },
+    });
+
+    // The submit button should be enabled now
+    expect(submitButton).not.toBeDisabled();
+  });
+
+  it("shows loading state while creating the tag", async () => {
+    vi.mocked(useCreateTag).mockReturnValue({
+      mutateAsync: mockCreateTag,
+      isPending: true, // Simulate loading state
+    } as unknown as ReturnType<typeof useCreateTag>);
+
+    render(<CreateTagForm />);
+
+    // Wait for the button text to change to "Creating..."
+    const submitButton = await screen.findByRole("button", {
+      name: /Create Tag|Creating.../,
+    });
+
+    // The button should display "Creating..." and be disabled
+    expect(submitButton).toHaveTextContent("Creating...");
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("clears form inputs after successful submission", async () => {
+    render(<CreateTagForm />);
+
+    const nameInput = screen.getByPlaceholderText("Tag name");
+    const descriptionInput = screen.getByPlaceholderText("Tag description");
+    const submitButton = screen.getByRole("button", { name: "Create Tag" });
+
+    fireEvent.change(nameInput, { target: { value: "NewTag" } });
+    fireEvent.change(descriptionInput, { target: { value: "Description" } });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      // After form submission, inputs should be cleared
+      expect(nameInput).toHaveValue("");
+      expect(descriptionInput).toHaveValue("");
+    });
+  });
+
+  it("does not submit if fields are empty", async () => {
+    render(<CreateTagForm />);
+
+    const nameInput = screen.getByPlaceholderText("Tag name");
+    const descriptionInput = screen.getByPlaceholderText("Tag description");
+    const submitButton = screen.getByRole("button", { name: "Create Tag" });
+
+    fireEvent.change(nameInput, { target: { value: "" } });
+    fireEvent.change(descriptionInput, { target: { value: "" } });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      // The submit function should not be called because inputs are empty
+      expect(mockCreateTag).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/CreateTagForm.tsx
+++ b/frontend/src/components/CreateTagForm.tsx
@@ -1,0 +1,60 @@
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { useCreateTag } from "@/services/api/programmingForumComponents";
+import { useState } from "react";
+
+interface CreateTagFormProps {
+  onCreateSuccess?: () => void; // Optional callback for successful tag creation
+}
+
+export function CreateTagForm({ onCreateSuccess }: CreateTagFormProps) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  const { mutateAsync: createTag, isPending } = useCreateTag();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !description.trim()) return;
+
+    try {
+      await createTag({
+        body: { name, description },
+      });
+      setName("");
+      setDescription("");
+      if (onCreateSuccess) onCreateSuccess();
+      // Optionally refresh the tag list or show a success message
+    } catch (error) {
+      console.error("Failed to create tag:", error);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-4">
+
+      <Input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Tag name"
+        className="min-w-[200px]"
+        required
+      />
+
+      <Textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Tag description"
+        className="min-h-[100px]"
+        required
+      />
+
+      <div className="flex justify-end">
+        <Button type="submit" disabled={isPending || !name.trim() || !description.trim()}>
+          {isPending ? "Creating..." : "Create Tag"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/CreateTagPage.test.tsx
+++ b/frontend/src/components/CreateTagPage.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CreateTagPage from "./CreateTagPage"; // Adjust path to the component
+import { useCreateTag } from "@/services/api/programmingForumComponents"; // Import the API hook
+
+// Mock the API hook used in CreateTagForm
+vi.mock("@/services/api/programmingForumComponents", () => ({
+  useCreateTag: vi.fn(),
+}));
+
+describe("CreateTagPage", () => {
+  const mockCreateTag = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock the hook to simulate a successful submission
+    vi.mocked(useCreateTag).mockReturnValue({
+      mutateAsync: mockCreateTag,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateTag>);
+  });
+
+  it("renders CreateTagForm correctly", () => {
+    render(<CreateTagPage />);
+
+    // Check if the form title is displayed
+    expect(screen.getByText("Create a New Tag")).toBeInTheDocument();
+    // Check if input fields are displayed
+    expect(screen.getByPlaceholderText("Tag name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Tag description")).toBeInTheDocument();
+    // Check if the submit button is displayed
+    expect(
+      screen.getByRole("button", { name: "Create Tag" }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits the form with valid data", async () => {
+    render(<CreateTagPage />);
+
+    const nameInput = screen.getByPlaceholderText("Tag name");
+    const descriptionInput = screen.getByPlaceholderText("Tag description");
+    const submitButton = screen.getByRole("button", { name: "Create Tag" });
+
+    // Simulate filling in the form
+    fireEvent.change(nameInput, { target: { value: "New Tag" } });
+    fireEvent.change(descriptionInput, {
+      target: { value: "Description of the new tag" },
+    });
+
+    // Simulate form submission
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      // Ensure the createTag function was called with the correct parameters
+      expect(mockCreateTag).toHaveBeenCalledWith({
+        body: {
+          name: "New Tag",
+          description: "Description of the new tag",
+        },
+      });
+    });
+  });
+
+  it("disables the submit button when fields are empty", () => {
+    render(<CreateTagPage />);
+
+    const submitButton = screen.getByRole("button", { name: "Create Tag" });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("enables the submit button when fields are filled", () => {
+    render(<CreateTagPage />);
+
+    const nameInput = screen.getByPlaceholderText("Tag name");
+    const descriptionInput = screen.getByPlaceholderText("Tag description");
+    const submitButton = screen.getByRole("button", { name: "Create Tag" });
+
+    // Fill the fields
+    fireEvent.change(nameInput, { target: { value: "New Tag" } });
+    fireEvent.change(descriptionInput, {
+      target: { value: "Description of the new tag" },
+    });
+
+    expect(submitButton).toBeEnabled();
+  });
+
+  it("displays loading state while submitting", async () => {
+    // Mock the API hook to simulate a pending request
+    vi.mocked(useCreateTag).mockReturnValue({
+      mutateAsync: mockCreateTag,
+      isPending: true,
+    } as unknown as ReturnType<typeof useCreateTag>);
+
+    render(<CreateTagPage />);
+  });
+
+  it("clears the input fields after successful submission", async () => {
+    render(<CreateTagPage />);
+
+    const nameInput = screen.getByPlaceholderText("Tag name");
+    const descriptionInput = screen.getByPlaceholderText("Tag description");
+    const submitButton = screen.getByRole("button", { name: "Create Tag" });
+
+    // Fill the fields
+    fireEvent.change(nameInput, { target: { value: "New Tag" } });
+    fireEvent.change(descriptionInput, {
+      target: { value: "Description of the new tag" },
+    });
+
+    // Submit the form
+    fireEvent.click(submitButton);
+
+    // Simulate successful submission
+    await waitFor(() => {
+      expect(nameInput).toHaveValue("");
+      expect(descriptionInput).toHaveValue("");
+    });
+  });
+});

--- a/frontend/src/components/CreateTagPage.tsx
+++ b/frontend/src/components/CreateTagPage.tsx
@@ -1,0 +1,16 @@
+import { CreateTagForm } from "@/components/CreateTagForm"; // Import the CreateTagForm component
+
+export default function CreateTagPage() {
+  return (
+    <div className="container py-8">
+      <h1 className="text-2xl font-bold mb-4">Create a New Tag</h1>
+
+      <CreateTagForm
+        onCreateSuccess={() => {
+          // Logic to handle post-create actions (e.g., show success message, refresh list, etc.)
+          console.log("Tag created successfully!");
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/NavbarLayout.tsx
+++ b/frontend/src/components/NavbarLayout.tsx
@@ -30,7 +30,7 @@ import { SearchBar } from "./SearchBar";
 import { Button } from "./ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet";
 
-const links = [{ name: "Home", path: "/" }] as const;
+const links = [{ name: "Home", path: "/" }, { name: "Tags", path: "/tags" } ] as const;
 
 export const NavbarLayout = () => {
   const navigation = useNavigation();

--- a/frontend/src/components/Tags.tsx
+++ b/frontend/src/components/Tags.tsx
@@ -1,0 +1,63 @@
+//import { CreateTagForm } from "@/components/CreateTagForm";
+import { TagCard } from "@/components/TagCard";
+import { useSearchTags } from "@/services/api/programmingForumComponents"; // Import your API hook
+import { TagDetails } from "@/services/api/programmingForumSchemas"; // Assuming this is the correct type for tags
+import { FullscreenLoading } from "../components/FullscreenLoading";
+import { useSearchParams, Link } from "react-router-dom";
+import ErrorAlert from "@/components/ErrorAlert";
+import { Button } from "@/components/ui/button"; // Assuming Button is a component
+import Plus from "@/assets/Icon/General/Plus.svg?react";
+
+export default function TagsPage() {
+  // Using the `useSearchTags` hook to fetch the default 20 tags
+  const [params] = useSearchParams();
+  const {
+    data: searchResult,
+    isLoading,
+    error,
+  } = useSearchTags({
+    queryParams: { q: params.get("q") ?? "" }, // No query parameter needed to fetch the default 20 tags
+  });
+
+  // If the API is still loading, show the loading component
+  if (isLoading) {
+    return <FullscreenLoading overlay />;
+  }
+
+  // If there is an error during the fetch, display the error alert
+  if (error) {
+    return <ErrorAlert error={error} />;
+  }
+
+  // Extracting tags from the API response
+  const tags = (searchResult?.data as { items?: TagDetails[] }).items || [];
+
+  return (
+    <div className="container py-8">
+      {/* Container for the title and the plus button */}
+      <div className="flex items-center gap-2 py-4">
+        <h1 className="text-2xl font-bold">Tags</h1>
+
+        {/* Button to navigate to create tag page */}
+        <Button
+          asChild
+          size="icon"
+          className="rounded-full bg-red-500 text-white"
+        >
+          <Link to="/tags/new">
+            <Plus />
+          </Link>
+        </Button>
+      </div>
+
+      {/* Section for displaying all tags */}
+      <div>
+        <div className="grid grid-cols-3 gap-4">
+          {tags.map((tag) => (
+            <TagCard key={tag.tagId} tag={tag} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -9,6 +9,9 @@ import { Search } from "./search";
 import Signup from "./signup";
 import TagPage from "./tag";
 import Profile from "./profile";
+import TagsPage from "@/components/Tags";
+import CreateTagPage from "@/components/CreateTagPage"; // Import the new CreateTagPage
+
 
 export const routes: RouteObject[] = [
   {
@@ -45,6 +48,14 @@ export const routes: RouteObject[] = [
   {
     path: "tag/:tagId",
     Component: TagPage,
+  },
+  {
+    path: "/tags", 
+    Component: TagsPage,
+  },
+  {
+    path: "/tags/new", 
+    Component: CreateTagPage,
   },
 ];
 


### PR DESCRIPTION
## 📋 Proposed Changes

  - The tag create page allows user to create a new tag with name and description fields.
  - The tags tab displays all tags and allows user to create a new tag from that tab.

## Related Issue
Closes #504.

## 🧪 Included Tests
- [X] The user enters a valid name and description.
- [X] The newly created tag is listed under All Tags under the Tags tab.
