### PR TITLE
[Frontend] Show Execution Time

### DIFF
--- a/frontend/src/components/CodeSnippet.tsx
+++ b/frontend/src/components/CodeSnippet.tsx
@@ -27,7 +27,7 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({ code, language }) => {
   const executeCode = useExecuteCode();
   const [executionTime, setExecutionTime] = useState<number | null>(null);
 
-  const handleExecute = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleExecute = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     setExecutionTime(null); // Reset the timer
     const execution: CodeExecution = {
@@ -36,10 +36,10 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({ code, language }) => {
     };
     const startTime = performance.now(); // Record start time
     try {
-      executeCode.mutate({ body: execution });
+      await executeCode.mutateAsync({ body: execution });
       const endTime = performance.now(); // Record end time
       setExecutionTime(endTime - startTime); // Calculate and set execution time
-    } catch (error) {
+    } catch {
       setExecutionTime(null); // Reset in case of error
     }
   };
@@ -94,7 +94,7 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({ code, language }) => {
           <pre className="bg-green-50 p-1">{executeCode.data.data.output}</pre>
           <br></br>
           {executionTime !== null && (
-            <p className="mb-4 text-sm font-bold">Execution Time: {executionTime.toFixed(2)} seconds</p>
+            <p className="mb-4 text-sm font-bold">Execution Time: {(executionTime / 1000).toFixed(3)} seconds</p>
           )}
         </div>
       )}

--- a/frontend/src/components/CodeSnippet.tsx
+++ b/frontend/src/components/CodeSnippet.tsx
@@ -31,7 +31,6 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({ code, language }) => {
       code,
       language: language as CodeExecution["language"],
     };
-    const startTime = performance.now(); // Record start time
     executeCode.mutate({ body: execution });
   };
 

--- a/frontend/src/components/CodeSnippet.tsx
+++ b/frontend/src/components/CodeSnippet.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/use-toast";
 import { useExecuteCode } from "@/services/api/programmingForumComponents";
 import { CodeExecution } from "@/services/api/programmingForumSchemas";
-import React, { useState } from "react";
+import React from "react";
 import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
 import { a11yLight } from "react-syntax-highlighter/dist/esm/styles/hljs";
 
@@ -25,23 +25,14 @@ const languageUserFriendlyName = {
 
 export const CodeSnippet: React.FC<CodeSnippetProps> = ({ code, language }) => {
   const executeCode = useExecuteCode();
-  const [executionTime, setExecutionTime] = useState<number | null>(null);
-
   const handleExecute = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    setExecutionTime(null); // Reset the timer
     const execution: CodeExecution = {
       code,
       language: language as CodeExecution["language"],
     };
     const startTime = performance.now(); // Record start time
-    try {
-      await executeCode.mutateAsync({ body: execution });
-      const endTime = performance.now(); // Record end time
-      setExecutionTime(endTime - startTime); // Calculate and set execution time
-    } catch {
-      setExecutionTime(null); // Reset in case of error
-    }
+    executeCode.mutate({ body: execution });
   };
 
   return (
@@ -90,12 +81,8 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({ code, language }) => {
       </Button>
       {executeCode.isSuccess && (
         <div className="mt-2 rounded border border-green-300 bg-green-100 p-2">
-          <h4 className="mb-4 text-sm font-bold">Output:</h4>
+          <h4 className="mb-4 text-sm font-bold">Output (in {executeCode.data.data.executionTime}s):</h4>
           <pre className="bg-green-50 p-1">{executeCode.data.data.output}</pre>
-          <br></br>
-          {executionTime !== null && (
-            <p className="mb-4 text-sm font-bold">Execution Time: {(executionTime / 1000).toFixed(3)} seconds</p>
-          )}
         </div>
       )}
       {executeCode.isError && (

--- a/frontend/src/components/CodeSnippet.tsx
+++ b/frontend/src/components/CodeSnippet.tsx
@@ -25,7 +25,7 @@ const languageUserFriendlyName = {
 
 export const CodeSnippet: React.FC<CodeSnippetProps> = ({ code, language }) => {
   const executeCode = useExecuteCode();
-  const handleExecute = async (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleExecute = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     const execution: CodeExecution = {
       code,

--- a/frontend/src/components/CodeSnippet.tsx
+++ b/frontend/src/components/CodeSnippet.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/use-toast";
 import { useExecuteCode } from "@/services/api/programmingForumComponents";
 import { CodeExecution } from "@/services/api/programmingForumSchemas";
-import React from "react";
+import React, { useState } from "react";
 import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
 import { a11yLight } from "react-syntax-highlighter/dist/esm/styles/hljs";
 
@@ -25,14 +25,23 @@ const languageUserFriendlyName = {
 
 export const CodeSnippet: React.FC<CodeSnippetProps> = ({ code, language }) => {
   const executeCode = useExecuteCode();
+  const [executionTime, setExecutionTime] = useState<number | null>(null);
 
   const handleExecute = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
+    setExecutionTime(null); // Reset the timer
     const execution: CodeExecution = {
       code,
       language: language as CodeExecution["language"],
     };
-    executeCode.mutate({ body: execution });
+    const startTime = performance.now(); // Record start time
+    try {
+      executeCode.mutate({ body: execution });
+      const endTime = performance.now(); // Record end time
+      setExecutionTime(endTime - startTime); // Calculate and set execution time
+    } catch (error) {
+      setExecutionTime(null); // Reset in case of error
+    }
   };
 
   return (
@@ -83,6 +92,10 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({ code, language }) => {
         <div className="mt-2 rounded border border-green-300 bg-green-100 p-2">
           <h4 className="mb-4 text-sm font-bold">Output:</h4>
           <pre className="bg-green-50 p-1">{executeCode.data.data.output}</pre>
+          <br></br>
+          {executionTime !== null && (
+            <p className="mb-4 text-sm font-bold">Execution Time: {executionTime.toFixed(2)} seconds</p>
+          )}
         </div>
       )}
       {executeCode.isError && (


### PR DESCRIPTION
## 📋 Proposed Changes

  - Show the execution time in Code Execution blocks.

Here is an example below: 

<img width="995" alt="image" src="https://github.com/user-attachments/assets/278524db-81a9-47dd-ad3e-f77db5af2448" />


## Related Issue
Closes #593 

