### PR TITLE
[Frontend] Use sr-only text

### DIFF
--- a/frontend/src/components/FullscreenLoading.tsx
+++ b/frontend/src/components/FullscreenLoading.tsx
@@ -26,7 +26,11 @@ export const FullscreenLoading = ({
       <Loader2
         className="h-16 w-16 animate-spin text-primary"
       />
-      <span className="sr-only">Loading</span>
+      {!takingLong && (
+        <div className="ml-4 text-lg font-normal duration-500 animate-in fade-in">
+          Loading...
+        </div>
+      )}
       {takingLong && (
         <div className="ml-4 text-lg font-normal duration-500 animate-in fade-in">
           This is taking a while...

--- a/frontend/src/components/FullscreenLoading.tsx
+++ b/frontend/src/components/FullscreenLoading.tsx
@@ -24,9 +24,9 @@ export const FullscreenLoading = ({
       )}
     >
       <Loader2
-        aria-label="Loading"
         className="h-16 w-16 animate-spin text-primary"
       />
+      <span className="sr-only">Loading</span>
       {takingLong && (
         <div className="ml-4 text-lg font-normal duration-500 animate-in fade-in">
           This is taking a while...

--- a/frontend/src/components/FullscreenLoading.tsx
+++ b/frontend/src/components/FullscreenLoading.tsx
@@ -33,6 +33,7 @@ export const FullscreenLoading = ({
       )}
       {takingLong && (
         <div className="ml-4 text-lg font-normal duration-500 animate-in fade-in">
+          <span className="sr-only">Loading...</span>
           This is taking a while...
         </div>
       )}

--- a/frontend/src/components/SearchQuestionsList.tsx
+++ b/frontend/src/components/SearchQuestionsList.tsx
@@ -102,9 +102,9 @@ export const SearchQuestionsList = () => {
         {isLoading && (
           <div className="col-span-3 flex w-full items-center justify-center">
             <Loader2
-              aria-label="Loading"
               className="h-16 w-16 animate-spin text-primary"
             />
+            <span className="sr-only">Loading</span>
           </div>
         )}
       </div>

--- a/frontend/src/components/SearchQuestionsList.tsx
+++ b/frontend/src/components/SearchQuestionsList.tsx
@@ -104,7 +104,9 @@ export const SearchQuestionsList = () => {
             <Loader2
               className="h-16 w-16 animate-spin text-primary"
             />
-            <span className="sr-only">Loading</span>
+            <div className="ml-4 text-lg font-normal duration-500 animate-in fade-in">
+              Loading...
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/components/SearchTagsList.tsx
+++ b/frontend/src/components/SearchTagsList.tsx
@@ -81,9 +81,9 @@ export const SearchTagsList = () => {
         {isLoading && (
           <div className="col-span-3 flex w-full items-center justify-center">
             <Loader2
-              aria-label="Loading"
               className="h-16 w-16 animate-spin text-primary"
             />
+            <span className="sr-only">Loading</span>
           </div>
         )}
       </div>

--- a/frontend/src/components/SearchTagsList.tsx
+++ b/frontend/src/components/SearchTagsList.tsx
@@ -83,7 +83,9 @@ export const SearchTagsList = () => {
             <Loader2
               className="h-16 w-16 animate-spin text-primary"
             />
-            <span className="sr-only">Loading</span>
+            <div className="ml-4 text-lg font-normal duration-500 animate-in fade-in">
+              Loading...
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/components/Tags.tsx
+++ b/frontend/src/components/Tags.tsx
@@ -88,9 +88,9 @@ export default function TagsPage() {
           {isLoading && (
             <div className="col-span-3 flex w-full items-center justify-center">
               <Loader2
-                aria-label="Loading"
                 className="h-16 w-16 animate-spin text-primary"
               />
+              <span className="sr-only">Loading</span>
             </div>
           )}
         </div>

--- a/frontend/src/components/Tags.tsx
+++ b/frontend/src/components/Tags.tsx
@@ -90,7 +90,9 @@ export default function TagsPage() {
               <Loader2
                 className="h-16 w-16 animate-spin text-primary"
               />
-              <span className="sr-only">Loading</span>
+              <div className="ml-4 text-lg font-normal duration-500 animate-in fade-in">
+                Loading...
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/routes/bookmarks.tsx
+++ b/frontend/src/routes/bookmarks.tsx
@@ -92,7 +92,9 @@ export const BookmarkedQuestions = () => {
             <Loader2
               className="h-16 w-16 animate-spin text-primary"
             />
-            <span className="sr-only">Loading</span>
+            <div className="ml-4 text-lg font-normal duration-500 animate-in fade-in">
+              Loading...
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/routes/bookmarks.tsx
+++ b/frontend/src/routes/bookmarks.tsx
@@ -90,9 +90,9 @@ export const BookmarkedQuestions = () => {
         {isLoading && (
           <div className="col-span-3 flex w-full items-center justify-center">
             <Loader2
-              aria-label="Loading"
               className="h-16 w-16 animate-spin text-primary"
             />
+            <span className="sr-only">Loading</span>
           </div>
         )}
       </div>

--- a/frontend/src/routes/profile.test.tsx
+++ b/frontend/src/routes/profile.test.tsx
@@ -53,7 +53,7 @@ describe("Profile component", () => {
 
     render(<RouterProvider router={router} />);
 
-    expect(screen.getByLabelText(/loading/i)).toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("displays user data correctly", async () => {

--- a/frontend/src/routes/search.test.tsx
+++ b/frontend/src/routes/search.test.tsx
@@ -55,7 +55,7 @@ describe("Search component", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByLabelText(/loading/i)).toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("renders tags correctly", () => {

--- a/frontend/src/routes/tag.tsx
+++ b/frontend/src/routes/tag.tsx
@@ -125,12 +125,9 @@ export default function TagPage() {
       </div>
       <div className="grid grid-cols-2 gap-4">
         {tag.fileExtension && (
-          <div
-            className="flex items-center gap-2"
-            aria-label={`File extension for ${tag.name} is ${tag.fileExtension}`}
-          >
+          <div className="flex items-center gap-2">
             <FileText className="h-5 w-5" />
-
+            <span className="sr-only">File extension for ${tag.name} is ${tag.fileExtension}</span>
             <span className="text-sm text-gray-500">{tag.fileExtension}</span>
           </div>
         )}
@@ -146,14 +143,12 @@ export default function TagPage() {
         )}
 
         {tag.inceptionYear && (
-          <div
-            className="flex items-center gap-2"
-            aria-label={`Inception year for ${tag.name} is ${tag.inceptionYear}`}
-          >
+          <div className="flex items-center gap-2">
             <Calendar className="h-5 w-5" />
             <span className="text-sm text-gray-500">
               Created in {new Date(tag.inceptionYear).toLocaleDateString()}
             </span>
+            <span className="sr-only"> Inception year for ${tag.name} is ${tag.inceptionYear} </span>
           </div>
         )}
 


### PR DESCRIPTION
## 📋 Proposed Changes

  - Use sr-only text instead of aria labels for non-interactive elements.
  - Make loading messages visible.

## Related Issue
Closes #609 

## 🧪 Included Tests
- [X] Loading messages are seen in Profile and Search pages.
